### PR TITLE
#115 - Checked mails depend on current tag

### DIFF
--- a/web-ui/app/js/mail_list/ui/mail_list.js
+++ b/web-ui/app/js/mail_list/ui/mail_list.js
@@ -75,7 +75,10 @@ define(
         if (data.ident) {
           self.attr.currentMailIdent = data.ident;
         }
+
         self.attr.currentTag = data.tag || self.attr.currentTag;
+
+	  self.updateCheckAllCheckbox();
       }
 
       function renderMails(mails) {
@@ -132,16 +135,24 @@ define(
       };
 
       this.respondWithCheckedMails = function (ev, caller) {
-        this.trigger(caller, events.ui.mail.hereChecked, { checkedMails : this.attr.checkedMails });
+        this.trigger(caller, events.ui.mail.hereChecked, { checkedMails : this.checkedMailsForCurrentTag()});
       };
 
       this.updateCheckAllCheckbox = function () {
-        if (_.keys(this.attr.checkedMails).length > 0) {
+        if (this.checkedMailsForCurrentTag().length > 0) {
           this.trigger(document, events.ui.mails.hasMailsChecked, true);
         } else {
           this.trigger(document, events.ui.mails.hasMailsChecked, false);
         }
       };
+
+	this.checkedMailsForCurrentTag = function() {
+	    var checkedMailsForCurrentTag =  _.filter(self.attr.checkedMails, function(mail) {
+		  return _.contains(mail.tags, self.attr.currentTag);
+	    });
+	    
+	    return checkedMailsForCurrentTag.length > 0 ? checkedMailsForCurrentTag : {};
+	}
 
       this.addToSelectedMails = function (ev, data) {
         this.attr.checkedMails[data.mail.ident] = data.mail;

--- a/web-ui/test/spec/mail_list/ui/mail_list.spec.js
+++ b/web-ui/test/spec/mail_list/ui/mail_list.spec.js
@@ -70,17 +70,18 @@ describeComponent('mail_list/ui/mail_list', function () {
       expect(this.component.attr.checkedMails).toEqual(checkedMails);
     });
 
-    it('returns the list of checked mails to whomever requests them', function () {
+    it('returns the list of checked mails based on the current tag to whomever requests them', function () {
       var caller = {};
-      this.component.attr.checkedMails = {'1': {}};
+      this.component.attr.checkedMails = mailList;
+	this.component.attr.currentTag = 'inbox';
       var mailHereCheckedEvent = spyOnEvent(caller, Pixelated.events.ui.mail.hereChecked);
 
       $(document).trigger(Pixelated.events.ui.mail.wantChecked, caller);
 
-      expect(mailHereCheckedEvent).toHaveBeenTriggeredOnAndWith(caller, { checkedMails: {'1': {} }});
+      expect(mailHereCheckedEvent).toHaveBeenTriggeredOnAndWith(caller, { checkedMails: mailList });
     });
 
-    it('returns an empty list to whomever requests the checked mails if there are no checked mails', function () {
+    it('returns an empty list to whomever requests the checked mails if there are no checked mails with the current tag', function () {
       var caller = {};
       var mailHereCheckedEvent = spyOnEvent(caller, Pixelated.events.ui.mail.hereChecked);
 
@@ -101,8 +102,18 @@ describeComponent('mail_list/ui/mail_list', function () {
       expect(this.component.attr.checkedMails).toEqual({'2': {}, '3': {} });
     });
 
-    it('checks the check all checkbox if at least one mail is checked', function () {
+    it ('does not check the all checkbox if no mail checked has the current tag', function () {
+	  var setCheckAllCheckboxEvent = spyOnEvent(document, Pixelated.events.ui.mails.hasMailsChecked);
+	  this.component.attr.currentTag = 'inbox';
+
+	  $(document).trigger(Pixelated.events.ui.mail.checked, {mail : {'1' : {tags: ['different']}}});
+
+	  expect(setCheckAllCheckboxEvent).toHaveBeenTriggeredOnAndWith(document, false);
+    });
+
+    it('checks the check all checkbox if at least one mail is checked with the current tag', function () {
       var setCheckAllCheckboxEvent = spyOnEvent(document, Pixelated.events.ui.mails.hasMailsChecked);
+	this.component.attr.currentTag = 'inbox';
 
       $(document).trigger(Pixelated.events.ui.mail.checked, {mail: mailList[0]});
 


### PR DESCRIPTION
This PR fixes issue #115 .

The main change is that now `mail_list` considers only checked mails that contain the `currentTag`. This means that any action performed (bulk read/unread, delete, etc.) will be applied only for checked mails containing the current tag (this behaves the same way gmail does).
