### PR TITLE
Adding ability to spin up a vagrant to run the service

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,119 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/trusty64"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  # config.vm.box_url = "http://domain.com/path/to/above.box"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network :forwarded_port, guest: 3333, host: 3333
+
+  config.vm.provision :shell, path: "provisioning/provision.sh"
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network :private_network, ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file precise64.pp in the manifests_path directory.
+  #
+  # An example Puppet manifest to provision the message of the day:
+  #
+  # # group { "puppet":
+  # #   ensure => "present",
+  # # }
+  # #
+  # # File { owner => 0, group => 0, mode => 0644 }
+  # #
+  # # file { '/etc/motd':
+  # #   content => "Welcome to your Vagrant-built virtual machine!
+  # #               Managed by Puppet.\n"
+  # # }
+  #
+  # config.vm.provision :puppet do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "init.pp"
+  # end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision :chef_solo do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { :mysql_password => "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision :chef_client do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+end

--- a/provisioning/README.md
+++ b/provisioning/README.md
@@ -1,0 +1,22 @@
+ Setup for developers
+=====================
+The following instructions describe how to setup a Vagrant box for development. You need to have Vagrant installed on your system.
+
+# Vagrant setup
+
+Create and provision Vagrant box
+```sh
+$ vagrant up
+```
+
+# Running the server
+Activate virtualenv and run Pixelated server
+```sh
+$ cd /vagrant/service
+$ source .virtualenv/bin/activate
+$ pixelated-user-agent --host 0.0.0.0
+```
+
+After this you will be asked to setup a LEAP provider. Once entering valid LEAP credentials, you should have the server running.
+
+You should now be able to access the web app by typing localhost:3333 on any browser running on your host machine.

--- a/provisioning/bootstrap.sh
+++ b/provisioning/bootstrap.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Copyright (c) 2014 ThoughtWorks, Inc.
+#
+# Pixelated is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Pixelated is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+
+# test dependencies
+function check_installed() {
+        which $1
+        if [ $? -ne 0 ]; then
+                echo "## You must have ${1} installed and in the PATH to run Pixelated-User-Agent"
+                echo "## exiting..."
+                exit 1
+        fi
+}
+
+for dependency in node npm ruby bundle virtualenv git gpg; do
+        check_installed $dependency
+done
+
+# install web-ui dependencies
+cd /vagrant/web-ui
+npm install
+node_modules/bower/bin/bower install --config.interactive=false
+bundle install
+LC_ALL=en_US.UTF-8 ./go build
+
+# install service dependencies
+cd ../service
+virtualenv .virtualenv
+source .virtualenv/bin/activate
+./go develop --always-unzip
+pip uninstall -y gnupg; pip install gnupg
+
+# print usage
+cat <<EOF
+
+###############
+
+## You will need an account in a LEAP provider. You may find some at http://bitmask.net/
+
+## Once you have it, modify the service/pixelated.example file and move it to ~/.pixelated
+
+## You might also need to add your LEAP provider ssl certificate to the pixelated/certificates folder, named as your provider domain name (in case it uses TLS):
+##      - example: your.leapprovider.org.crt
+
+## Once you are done, just run:
+##        pixelated-user-agent
+
+EOF

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -1,0 +1,13 @@
+sudo apt-get update
+sudo apt-get install -y git
+sudo apt-get install -y nodejs-legacy
+sudo apt-get install -y npm
+sudo apt-get install -y python-setuptools
+sudo easy_install pip
+sudo pip install virtualenv
+sudo apt-get install -y python-dev
+sudo apt-get install -y libffi-dev
+sudo apt-get install -y g++
+sudo gem install bundler
+
+/vagrant/provisioning/bootstrap.sh


### PR DESCRIPTION
Added the Vagrantfile and the provisioning folder containing the needed scripts to get the service working.
The changes will enable to run the service in the vagrant box, have the code shared on the /vagrant folder and forward the 3333 port to the host machine. The would mean that people can work on their laptops and see the results on the browser while the service is running in the vagrant box
