### PR TITLE
Upgrade pip to fix parsing development_requirements.txt in setup service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+# IntelliJ nonsense
 .idea
+*.iml
+
 .bundle
 *.log
 *.DS_Store

--- a/service/setup.py
+++ b/service/setup.py
@@ -47,6 +47,7 @@ setup(name='pixelated-user-agent',
           'pixelated.extensions'
       ],
       install_requires=[
+           'pip==7.1.0',
            'pyasn1==0.1.8',
            'requests==2.0.0',
            'srp==1.0.4',


### PR DESCRIPTION
When running `./go setup` in `/vagrant/service`, this fixes the parsing error of  `development_requirements.txt` caused by the previous version of pip on the VM.