### PR TITLE
Eli: Marking sent emails as read

### DIFF
--- a/service/pixelated/adapter/services/mail_service.py
+++ b/service/pixelated/adapter/services/mail_service.py
@@ -98,6 +98,8 @@ class MailService(object):
         if last_draft_ident:
             yield self.mail_store.delete_mail(last_draft_ident)
         sent_mail = yield self.mail_store.add_mail('SENT', mail.raw)
+        sent_mail.flags.add(Status.SEEN)
+        yield self.mail_store.update_mail(sent_mail)
         defer.returnValue(sent_mail)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Fixes #374 although possibly not in the best way. We considered doing this in JavaScript. We also considered removing the concept of an 'unread' sent mail altogether. The problem with the latter would be if the user sets up an auto-reply. Would appreciate some guidance. 