### PR TITLE
#481 create a draft_button component

### DIFF
--- a/service/pixelated/adapter/mailstore/body_parser.py
+++ b/service/pixelated/adapter/mailstore/body_parser.py
@@ -49,13 +49,13 @@ class BodyParser(object):
         return parsed_body.get_payload(decode=True)
 
     def _serialize_for_parser(self, charset):
-        text = ''
-        text += 'Content-Type: %s\n' % self._content_type
+        text = u''
+        text += u'Content-Type: %s\n' % self._content_type
         if self._content_transfer_encoding is not None:
-            text += 'Content-Transfer-Encoding: %s\n' % self._content_transfer_encoding
-        text += '\n'
+            text += u'Content-Transfer-Encoding: %s\n' % self._content_transfer_encoding
+        text += u'\n'
+        encoded_text = text.encode(charset)
         if isinstance(self._content, unicode):
-            text = text.encode(charset) + self._content.encode(charset)
+            return encoded_text + self._content.encode(charset)
         else:
-            text += self._content
-        return text
+            return encoded_text + self._content

--- a/service/pixelated/adapter/mailstore/body_parser.py
+++ b/service/pixelated/adapter/mailstore/body_parser.py
@@ -34,10 +34,7 @@ class BodyParser(object):
 
     def parsed_content(self):
         charset = _parse_charset_header(self._content_type)
-        try:
-            text = self._serialize_for_parser(charset)
-        except Exception as error:
-            import ipdb; ipdb.set_trace()
+        text = self._serialize_for_parser(charset)
 
         decoded_body = self._parse_and_decode(text)
 

--- a/service/pixelated/adapter/mailstore/body_parser.py
+++ b/service/pixelated/adapter/mailstore/body_parser.py
@@ -49,13 +49,13 @@ class BodyParser(object):
         return parsed_body.get_payload(decode=True)
 
     def _serialize_for_parser(self, charset):
-        text = u''
-        text += u'Content-Type: %s\n' % self._content_type
+        text = u'Content-Type: %s\n' % self._content_type
         if self._content_transfer_encoding is not None:
             text += u'Content-Transfer-Encoding: %s\n' % self._content_transfer_encoding
+
         text += u'\n'
         encoded_text = text.encode(charset)
         if isinstance(self._content, unicode):
-            return encoded_text + self._content.encode(charset)
+            return encoded_text + self._content.encode(charset, 'ignore')
         else:
             return encoded_text + self._content

--- a/service/pixelated/adapter/mailstore/body_parser.py
+++ b/service/pixelated/adapter/mailstore/body_parser.py
@@ -34,7 +34,10 @@ class BodyParser(object):
 
     def parsed_content(self):
         charset = _parse_charset_header(self._content_type)
-        text = self._serialize_for_parser(charset)
+        try:
+            text = self._serialize_for_parser(charset)
+        except Exception as error:
+            import ipdb; ipdb.set_trace()
 
         decoded_body = self._parse_and_decode(text)
 
@@ -55,7 +58,7 @@ class BodyParser(object):
             text += 'Content-Transfer-Encoding: %s\n' % self._content_transfer_encoding
         text += '\n'
         if isinstance(self._content, unicode):
-            text += self._content.encode(charset)
+            text = text.encode(charset) + self._content.encode(charset)
         else:
             text += self._content
         return text

--- a/service/pixelated/adapter/search/__init__.py
+++ b/service/pixelated/adapter/search/__init__.py
@@ -19,6 +19,7 @@ from pixelated.support.encrypted_file_storage import EncryptedFileStorage
 import os
 import re
 import dateutil.parser
+import time
 from pixelated.adapter.model.status import Status
 from pixelated.adapter.search.contacts import contacts_suggestions
 from whoosh.index import FileIndex
@@ -126,7 +127,7 @@ class SearchEngine(object):
         index_data = {
             'sender': self._empty_string_to_none(header.get('from', '')),
             'subject': self._empty_string_to_none(header.get('subject', '')),
-            'date': dateutil.parser.parse(header.get('date', '')).strftime('%s'),
+            'date': self._format_utc_integer(header.get('date', '')),
             'to': self._format_recipient(header, 'to'),
             'cc': self._format_recipient(header, 'cc'),
             'bcc': self._format_recipient(header, 'bcc'),
@@ -138,6 +139,10 @@ class SearchEngine(object):
         }
 
         writer.update_document(**index_data)
+
+    def _format_utc_integer(self, date):
+        timetuple = dateutil.parser.parse(date).utctimetuple()
+        return time.strftime('%s', timetuple)
 
     def _format_recipient(self, headers, name):
         list = headers.get(name, [''])

--- a/service/pixelated/assets/Interstitial.js
+++ b/service/pixelated/assets/Interstitial.js
@@ -4,12 +4,13 @@ if ($('#hive').length) {
   var left_pos = img_width * .5;
 
   var pixelated = hive.path("M12.4,20.3v31.8l28,15.8l28-15.8V20.3l-28-15.8L12.4,20.3z M39.2,56.4l-16.3-9V27.9l16.3,9.3L39.2,56.4z M57.7,47.4l-16.1,9l0-19.2l16.1-9.4V47.4z M57.7,25.2L40.4,35.5L22.9,25.2l17.5-9.4L57.7,25.2z").transform("translate(319, 50)").attr("fill", "#908e8e");
-  var all = hive.group().transform("matrix(2, 0, 0, 2, "+(left_pos - 950)+", -40)");
+  var all = hive.group().transform("matrix(2, 0, 0, 2, -100, -100)");
 
   var height = 50;
   var width = 58;
-  var rows = $(window).height() / height;
+  var rows = (($(window).height() / height) / 2) + 1;
   var cols = (($(window).width() / width) / 2) + 1;
+
 
   for (var j = 0; j < rows; j++) {
     for (var i = 0; i < cols; i++) {

--- a/service/pixelated/bitmask_libraries/soledad.py
+++ b/service/pixelated/bitmask_libraries/soledad.py
@@ -16,6 +16,11 @@
 import errno
 
 import os
+from twisted.internet import reactor
+from leap.common.events import (
+    register,
+    catalog as events
+)
 from leap.soledad.client import Soledad
 from leap.soledad.common.crypto import WrongMacError, UnknownMacMethodError
 from pixelated.bitmask_libraries.certs import LeapCertificate
@@ -42,6 +47,7 @@ class SoledadSessionFactory(object):
 
 class SoledadSession(object):
     def __init__(self, provider, encryption_passphrase, user_token, user_uuid):
+        register(events.SOLEDAD_INVALID_AUTH_TOKEN, lambda _: reactor.stop())
         self.provider = provider
         self.config = provider.config
         self.user_uuid = user_uuid

--- a/web-ui/app/index.html
+++ b/web-ui/app/index.html
@@ -60,7 +60,6 @@
 <div class="off-canvas-wrap content" data-offcanvas>
   <header id="main" >
     <div id="user-alerts" class="message-panel"></div>
-    <div id="loading" class="message-panel"><span>Loading...</span></div>
   </header>
 
   <div class="inner-wrap">

--- a/web-ui/app/js/helpers/monitored_ajax.js
+++ b/web-ui/app/js/helpers/monitored_ajax.js
@@ -31,9 +31,6 @@ define(['page/events', 'views/i18n'], function (events, i18n) {
 
     var originalBeforeSend = config.beforeSend;
     config.beforeSend = function () {
-      if (!config.skipLoadingWarning) {
-        $('#loading').show();
-      }
       if (originalBeforeSend) {
         originalBeforeSend();
       }
@@ -41,9 +38,6 @@ define(['page/events', 'views/i18n'], function (events, i18n) {
 
     var originalComplete = config.complete;
     config.complete = function () {
-      if (!config.skipLoadingWarning) {
-        $('#loading').fadeOut(500);
-      }
       if (originalComplete) {
         originalComplete();
       }

--- a/web-ui/app/js/mail_view/data/mail_sender.js
+++ b/web-ui/app/js/mail_view/data/mail_sender.js
@@ -66,7 +66,6 @@ define(
           dataType: 'json',
           contentType: 'application/json; charset=utf-8',
           data: JSON.stringify(mail),
-          skipLoadingWarning: true,
           skipErrorMessage: true
         });
       };

--- a/web-ui/app/js/mail_view/ui/draft_button.js
+++ b/web-ui/app/js/mail_view/ui/draft_button.js
@@ -1,0 +1,41 @@
+/*
+* Copyright (c) 2014 ThoughtWorks, Inc.
+*
+* Pixelated is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Pixelated is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+*/
+'use strict';
+
+define([
+  'flight/lib/component',
+  'page/events',
+],
+function (defineComponent, events) {
+  return defineComponent(draftButton);
+
+  function draftButton() {
+    this.enableButton = function () {
+      this.$node.prop('disabled', false);
+    };
+
+    this.disableButton = function () {
+      this.$node.prop('disabled', true);
+    };
+
+    this.after('initialize', function(){
+      this.disableButton();
+      this.on(document, events.mail.saveDraft, this.disableButton);
+      this.on(document, events.mail.draftSaved, this.enableButton);
+    });
+  }
+});

--- a/web-ui/app/js/mixins/with_mail_edit_base.js
+++ b/web-ui/app/js/mixins/with_mail_edit_base.js
@@ -23,9 +23,10 @@ define(
     'page/events',
     'views/i18n',
     'mail_view/ui/send_button',
+    'mail_view/ui/draft_button',
     'flight/lib/utils'
   ],
-  function(viewHelper, Recipients, DraftSaveStatus, events, i18n, SendButton, utils) {
+  function(viewHelper, Recipients, DraftSaveStatus, events, i18n, SendButton, DraftButton, utils) {
     'use strict';
 
     function withMailEditBase() {
@@ -94,6 +95,7 @@ define(
         this.on(this.select('draftButton'), 'click', this.buildAndSaveDraft);
         this.on(this.select('trashButton'), 'click', this.trashMail);
         SendButton.attachTo(this.select('sendButton'));
+        DraftButton.attachTo(this.select('draftButton'));
 
         this.warnSendButtonOfRecipients();
       };

--- a/web-ui/app/locales/pt/translation.json
+++ b/web-ui/app/locales/pt/translation.json
@@ -9,7 +9,7 @@
     "Could not update mail tags": "Não foi possível atualizar as etiquetas do email",
     "Invalid tag name": "Nome de etiqueta inválido",
     "Could not delete email": "Não foi possível deletar o email",
-    "Could not fetch messages": "Não foi possível buscar as mensagems",
+    "Could not fetch messages": "Não foi possível buscar as mensagens",
     "sending-mail": "Enviando...",
 
     "tags": {

--- a/web-ui/test/spec/mail_view/ui/draft_button.spec.js
+++ b/web-ui/test/spec/mail_view/ui/draft_button.spec.js
@@ -9,7 +9,7 @@ describeComponent('mail_view/ui/draft_button', function(){
     });
 
     describe('after initialize', function(){
-      it('should be enabled', function(){
+      it('should be disabled', function(){
         expect(this.$node).toBeDisabled();
       });
     });

--- a/web-ui/test/spec/mail_view/ui/draft_button.spec.js
+++ b/web-ui/test/spec/mail_view/ui/draft_button.spec.js
@@ -1,0 +1,40 @@
+/* global Pixelated */
+
+describeComponent('mail_view/ui/draft_button', function(){
+  'use strict';
+
+  describe('draft save button', function(){
+    beforeEach(function(){
+      this.setupComponent('<button></button>');
+    });
+
+    describe('after initialize', function(){
+      it('should be enabled', function(){
+        expect(this.$node).toBeDisabled();
+      });
+    });
+
+    describe('when enabled', function(){
+      beforeEach(function(){
+        this.$node.prop('disabled', false);
+      });
+
+      it('should be disabled when saving draft message', function(){
+        $(document).trigger(Pixelated.events.mail.saveDraft, {});
+        expect(this.$node).toBeDisabled();
+      });
+    });
+
+    describe('when disabled', function(){
+      beforeEach(function(){
+        this.$node.prop('disabled', true);
+      });
+
+      it('should be enabled when draft message has been saved', function(){
+        $(document).trigger(Pixelated.events.mail.draftSaved, {});
+        expect(this.$node).not.toBeDisabled();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
Created a draft_button component that listens to `draft:save` and `draft:saved` events to know when to enable and disable itself. This should prevent spamming of the "Save Draft" button resulting in duplicate draft messages being save.

However, there may be other scenarios I've missed on the page.