### PR TITLE
pinned message header in read mode

### DIFF
--- a/web-ui/app/scss/_read.scss
+++ b/web-ui/app/scss/_read.scss
@@ -3,6 +3,7 @@
 @mixin read-msg {
   #mail-view {
     .msg-header {
+      position: fixed;
       display: flex;
       flex-wrap: nowrap;
 
@@ -11,7 +12,7 @@
       background-color: white;
       font-size: 0.9em;
       padding: 0px 0;
-      margin: 1px 0 0 0;
+      margin: 0px 0 0 0;
       .recipients {
         padding-bottom: 5px;
         line-height: 1.5em;
@@ -24,11 +25,13 @@
       }
       .close-mail-button {
         position: relative;
+        top: 1px;
+        left: 1px;
         float: none;
         flex-shrink: 0;
         display: inline-block;
         vertical-align: top;
-        height: 27px;
+        height: 25px;
         margin-right: 3px;
       }
 


### PR DESCRIPTION
I could not see any issues with the menu opening or resizing the window.
I also removed the 1px margin for the header so the body text would not be visible scrolling underneath, and adjusted the close button slightly so it would still look similar to the compose one.