### PR TITLE
[fix] remove pycryptopp dependency

### DIFF
--- a/service/pixelated/adapter/model/mail.py
+++ b/service/pixelated/adapter/model/mail.py
@@ -19,11 +19,11 @@ import logging
 from email import message_from_file
 from email.mime.text import MIMEText
 from email.header import Header
+from hashlib import sha256
 
 import binascii
 from email.MIMEMultipart import MIMEMultipart
 from email.mime.nonmultipart import MIMENonMultipart
-from pycryptopp.hash import sha256
 import leap.mail.walk as walk
 from pixelated.adapter.model.status import Status
 from pixelated.support import date
@@ -137,7 +137,7 @@ class Mail(object):
         return self._mime_multipart.as_string()
 
     def _get_chash(self):
-        return sha256.SHA256(self.raw).hexdigest()
+        return sha256(self.raw).hexdigest()
 
 
 class InputMail(Mail):

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -7,7 +7,6 @@ pyasn1==0.1.8
 requests==2.9.1
 srp==1.0.4
 whoosh==2.5.7
-pycryptopp
 -e 'git+https://github.com/pixelated/leap_pycommon.git@develop#egg=leap.common'
 -e 'git+https://github.com/pixelated/leap_auth.git#egg=leap.auth'
 -e 'git+https://github.com/pixelated/soledad.git@develop#egg=leap.soledad.common&subdirectory=common/'


### PR DESCRIPTION
cryptography is now a hard dependency, so we are removing the use of
pycryptopp.