### PR TITLE
RootResource should return 503 during startup

### DIFF
--- a/service/pixelated/resources/__init__.py
+++ b/service/pixelated/resources/__init__.py
@@ -23,7 +23,7 @@ from twisted.web.resource import Resource
 # from pixelated.resources.login_resource import LoginResource
 from pixelated.resources.session import IPixelatedSession
 
-from twisted.web.http import INTERNAL_SERVER_ERROR
+from twisted.web.http import INTERNAL_SERVER_ERROR, SERVICE_UNAVAILABLE
 log = logging.getLogger(__name__)
 
 
@@ -112,3 +112,12 @@ class UnAuthorizedResource(Resource):
     def render_POST(self, request):
         request.setResponseCode(UNAUTHORIZED)
         return "Unauthorized!"
+
+
+class UnavailableResource(Resource):
+    def __init__(self):
+        Resource.__init__(self)
+
+    def render(self, request):
+        request.setResponseCode(SERVICE_UNAVAILABLE)
+        return "Service Unavailable"

--- a/service/pixelated/resources/root_resource.py
+++ b/service/pixelated/resources/root_resource.py
@@ -57,10 +57,10 @@ class RootResource(BaseResource):
         if path == '':
             return self
         if self._is_xsrf_valid(request):
-            if self._mode == MODE_STARTUP:
-                return UnavailableResource()
-            else:
+            if self._mode == MODE_RUNNING:
                 return self._child_resources.get(path)
+            else:
+                return UnavailableResource()
         return UnAuthorizedResource()
 
     def _is_xsrf_valid(self, request):

--- a/service/pixelated/resources/root_resource.py
+++ b/service/pixelated/resources/root_resource.py
@@ -18,7 +18,7 @@ import json
 import os
 from string import Template
 
-from pixelated.resources import BaseResource, UnAuthorizedResource
+from pixelated.resources import BaseResource, UnAuthorizedResource, UnavailableResource
 from pixelated.resources.attachments_resource import AttachmentsResource
 from pixelated.resources.sandbox_resource import SandboxResource
 from pixelated.resources.contacts_resource import ContactsResource
@@ -57,7 +57,10 @@ class RootResource(BaseResource):
         if path == '':
             return self
         if self._is_xsrf_valid(request):
-            return self._child_resources.get(path)
+            if self._mode == MODE_STARTUP:
+                return UnavailableResource()
+            else:
+                return self._child_resources.get(path)
         return UnAuthorizedResource()
 
     def _is_xsrf_valid(self, request):

--- a/service/test/unit/resources/test_root_resource.py
+++ b/service/test/unit/resources/test_root_resource.py
@@ -68,6 +68,21 @@ class TestRootResource(unittest.TestCase):
         self.root_resource._mode = MODE_RUNNING
         self._test_should_renew_xsrf_cookie()
 
+    def test_should_unavailable_child_resource_during_startup(self):
+        self.root_resource._mode = MODE_STARTUP
+
+        request = DummyRequest(['/child'])
+        request.getCookie = MagicMock(return_value='irrelevant -- stubbed')
+
+        d = self.web.get(request)
+
+        def assert_unavailable(_):
+            self.assertEqual(503, request.responseCode)
+            self.assertEqual("Service Unavailable", request.written[0])
+
+        d.addCallback(assert_unavailable)
+        return d
+
     def _mock_ajax_csrf(self, request, csrf_token):
         request.requestHeaders.setRawHeaders('x-requested-with', ['XMLHttpRequest'])
         request.requestHeaders.setRawHeaders('x-xsrf-token', [csrf_token])

--- a/service/test/unit/resources/test_root_resource.py
+++ b/service/test/unit/resources/test_root_resource.py
@@ -107,6 +107,7 @@ class TestRootResource(unittest.TestCase):
 
         request.getCookie = MagicMock(return_value='irrelevant -- stubbed')
         self.root_resource._child_resources.add('features', FeaturesResource())
+        self.root_resource._mode = MODE_RUNNING
 
         d = self.web.get(request)
 


### PR DESCRIPTION
During the cryptohack virtual hack night last night, I spent a bit of time going over some of the hiccups I experienced in trying to get a development environment up and running, reorienting myself with twisted and getting familiar with the structure of the project. I came across some fairly gnarly stack traces that would happen between starting the user agent and the `user agent is ready` message appearing:

```
2016-05-26 04:38:35 [twisted] CRITICAL Unhandled Error
Traceback (most recent call last):
  File "/home/vagrant/user-agent-venv/local/lib/python2.7/site-packages/twisted/web/http.py", line 1688, in lineReceived
    self.allContentReceived()
  File "/home/vagrant/user-agent-venv/local/lib/python2.7/site-packages/twisted/web/http.py", line 1767, in allContentReceived
    req.requestReceived(command, path, version)
  File "/home/vagrant/user-agent-venv/local/lib/python2.7/site-packages/twisted/web/http.py", line 768, in requestReceived
    self.process()
  File "/vagrant/service/pixelated/config/site.py", line 18, in process
    Request.process(self)
--- <exception caught here> ---
  File "/home/vagrant/user-agent-venv/local/lib/python2.7/site-packages/twisted/web/server.py", line 183, in process
    self.render(resrc)
  File "/home/vagrant/user-agent-venv/local/lib/python2.7/site-packages/twisted/web/server.py", line 234, in render
    body = resrc.render(self)
exceptions.AttributeError: 'NoneType' object has no attribute 'render'
```

Turns out I had left my browser open in the background during the startup making ajax polls for new messages, and twisted was handling the web requests before `RootResource.initialize()` had been called. `RootResource.getChild()` was simply returning `None`.

This fixes that by having RootResource simply return a 503 until MODE_RUNNING is set.