### PR TITLE
Updated calls to addRawHeader to use setRawHeaders

### DIFF
--- a/service/pixelated/resources/__init__.py
+++ b/service/pixelated/resources/__init__.py
@@ -36,14 +36,14 @@ class SetEncoder(json.JSONEncoder):
 
 def respond_json(entity, request, status_code=200):
     json_response = json.dumps(entity, cls=SetEncoder)
-    request.responseHeaders.addRawHeader(b"content-type", [b"application/json"])
+    request.responseHeaders.setRawHeaders(b"content-type", [b"application/json"])
     request.code = status_code
     return json_response
 
 
 def respond_json_deferred(entity, request, status_code=200):
     json_response = json.dumps(entity, cls=SetEncoder)
-    request.responseHeaders.addRawHeader(b"content-type", [b"application/json"])
+    request.responseHeaders.setRawHeaders(b"content-type", [b"application/json"])
     request.code = status_code
     request.write(json_response)
     request.finish()

--- a/service/test/unit/resources/test_helpers.py
+++ b/service/test/unit/resources/test_helpers.py
@@ -1,0 +1,30 @@
+import unittest
+import re
+
+from pixelated.resources import respond_json, respond_json_deferred
+from test.unit.resources import DummySite
+from twisted.web.test.requesthelper import DummyRequest
+
+
+class TestHelpers(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_respond_json_should_populate_response(self):
+        request = DummyRequest([''])
+        body = respond_json({"test": "yep"}, request)
+
+        self.assertEqual(200, request.code)
+        self.assertEqual(b"{\"test\": \"yep\"}", body)
+        self.assertEqual([b"application/json"],
+                         request.responseHeaders.getRawHeaders("Content-Type"))
+
+    def test_respond_json_deferred_should_populate_response(self):
+        request = DummyRequest([''])
+        body = respond_json_deferred({"test": "yep"}, request)
+
+        self.assertEqual(200, request.code)
+        self.assertEqual(b"{\"test\": \"yep\"}", request.written[0])
+        self.assertEqual([b"application/json"],
+                         request.responseHeaders.getRawHeaders("Content-Type"))


### PR DESCRIPTION
I noticed that `respond_json` and `respond_json_deferred` were calling `addRawHeader` but passing a list as the argument, yielding the following HTTP header: `Content-Type: ['application/json']`.

This updates to use `setRawHeaders` instead, which does accept an array as the second parameter.