### PR TITLE
Issue 695: Show all recipients in mail sent folder

### DIFF
--- a/service/pixelated/adapter/services/mail_sender.py
+++ b/service/pixelated/adapter/services/mail_sender.py
@@ -15,6 +15,7 @@
 # along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
 from StringIO import StringIO
 from email.utils import parseaddr
+from copy import deepcopy
 from leap.mail.outgoing.service import OutgoingMail
 
 from twisted.internet.defer import Deferred, fail
@@ -47,6 +48,9 @@ class MailSender(object):
 
     @defer.inlineCallbacks
     def sendmail(self, mail):
+        # message is changed in sending, but should be saved unaltered
+        mail = deepcopy(mail)
+
         recipients = flatten([mail.to, mail.cc, mail.bcc])
 
         results = yield self._send_mail_to_all_recipients(mail, recipients)

--- a/service/test/unit/adapter/services/test_mail_sender.py
+++ b/service/test/unit/adapter/services/test_mail_sender.py
@@ -77,6 +77,20 @@ class MailSenderTest(unittest.TestCase):
             verify(OutgoingMail).send_message(any(), TwistedSmtpUserCapture(recipient))
 
     @defer.inlineCallbacks
+    def test_send_leaves_mail_in_tact(self):
+        input_mail_dict = mail_dict()
+        input_mail = InputMail.from_dict(input_mail_dict, from_address='pixelated@org')
+
+        when(OutgoingMail).send_message(any(), any()).thenReturn(defer.succeed(None))
+
+        yield self.sender.sendmail(input_mail)
+
+        self.assertEqual(input_mail.to, input_mail_dict["header"]["to"])
+        self.assertEqual(input_mail.cc, input_mail_dict["header"]["cc"])
+        self.assertEqual(input_mail.bcc, input_mail_dict["header"]["bcc"])
+        self.assertEqual(input_mail.subject, input_mail_dict["header"]["subject"])
+
+    @defer.inlineCallbacks
     def test_problem_with_email_raises_exception(self):
         input_mail = InputMail.from_dict(mail_dict(), from_address='pixelated@org')
 


### PR DESCRIPTION
`MailSender.sendmail` modifies the `InputMail` headers while sending. This breaks the expectation of the parent that the `InputMail` will be saved unmodified. A simple `deepcopy` does the trick.