### PR TITLE
Make whole mail item without tags clickable

### DIFF
--- a/web-ui/app/scss/views/_mail-list.scss
+++ b/web-ui/app/scss/views/_mail-list.scss
@@ -43,6 +43,7 @@
         display: block;
         color: $dark_grey;
         padding-left: 24px;
+        height: 100%;
 
         &-from {
             white-space: nowrap;


### PR DESCRIPTION
fixes #743
For mail items without tags the link to open the mail is not expanded,
therefore it has to be done via CSS