### PR TITLE
Simplifies the get_static_folder on RootResource

### DIFF
--- a/service/pixelated/resources/root_resource.py
+++ b/service/pixelated/resources/root_resource.py
@@ -111,11 +111,7 @@ class RootResource(BaseResource):
         return os.path.join(path, '..', 'assets')
 
     def _get_static_folder(self):
-        static_folder = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "..", "web-ui", "dist"))
-        # this is a workaround for packaging
-        if not os.path.exists(static_folder):
-            static_folder = os.path.abspath(
-                os.path.join(os.path.abspath(__file__), "..", "..", "..", "..", "web-ui", "dist"))
+        static_folder = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "..", "..", "web-ui", "dist"))
         if not os.path.exists(static_folder):
             static_folder = os.path.join('/', 'usr', 'share', 'pixelated-user-agent')
         return static_folder


### PR DESCRIPTION
There are only two possibilities currently:

- The static files are at web-ui/dist
- The static files are installed by the debian package
at /usr/share/pixelated-user-agent

This change removed the third non-existent possibility that was
causing errors sometimes in a new environment (service/web-ui/dist)