### PR TITLE
Fixed mockito conflict with zope

### DIFF
--- a/service/test/unit/config/test_site.py
+++ b/service/test/unit/config/test_site.py
@@ -1,10 +1,11 @@
 from twisted.trial import unittest
-from mockito import mock
+from mock import MagicMock
 from pixelated.config.site import PixelatedSite
 from twisted.protocols.basic import LineReceiver
 
 
 class TestPixelatedSite(unittest.TestCase):
+
     def test_add_security_headers(self):
         request = self.create_request()
         request.process()
@@ -36,7 +37,7 @@ class TestPixelatedSite(unittest.TestCase):
 
     def create_request(self):
         channel = LineReceiver()
-        channel.site = PixelatedSite(mock())
+        channel.site = PixelatedSite(MagicMock())
         request = PixelatedSite.requestFactory(channel=channel, queued=True)
         request.method = "GET"
         request.uri = "localhost"


### PR DESCRIPTION
I bumped into this problem where trial would try to clean up after
running the SiteTest and run into an error
'RememberedInvocation has no attribute "_implied"'

That happened because mockito is strict with the set of functions
it's mock accepts and _implied doesn't exist. It didn't really make
sense in this test context so I've adapted the test to use MagicMock
instead and now the test pass without problems.