### PR TITLE
Close session when UploadKeyError occurs

### DIFF
--- a/service/pixelated/config/sessions.py
+++ b/service/pixelated/config/sessions.py
@@ -19,7 +19,7 @@ from leap.common.events import (
     catalog as events
 )
 
-from pixelated.bitmask_libraries.keymanager import Keymanager
+from pixelated.bitmask_libraries.keymanager import Keymanager, UploadKeyError
 from pixelated.adapter.mailstore import LeapMailStore
 from pixelated.config import leap_config
 from pixelated.bitmask_libraries.certs import LeapCertificate
@@ -156,7 +156,12 @@ class LeapSession(object):
 
     @defer.inlineCallbacks
     def finish_bootstrap(self):
-        yield self.keymanager.generate_openpgp_key()
+        try:
+            yield self.keymanager.generate_openpgp_key()
+        except UploadKeyError as e:
+            logger.warn('{0}: {1}. Closing session for user: {2}'.format(e.__class__.__name__, e, self.account_email()))
+            self.close()
+
         yield self._create_account(self.soledad, self.user_auth.uuid)
         self.incoming_mail_fetcher = yield self._create_incoming_mail_fetcher(
             self.keymanager,

--- a/service/pixelated/config/sessions.py
+++ b/service/pixelated/config/sessions.py
@@ -161,6 +161,7 @@ class LeapSession(object):
         except UploadKeyError as e:
             logger.warn('{0}: {1}. Closing session for user: {2}'.format(e.__class__.__name__, e, self.account_email()))
             self.close()
+            raise
 
         yield self._create_account(self.soledad, self.user_auth.uuid)
         self.incoming_mail_fetcher = yield self._create_incoming_mail_fetcher(

--- a/service/test/unit/config/test_sessions.py
+++ b/service/test/unit/config/test_sessions.py
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
 
-import os
 from mock import patch
 from mock import MagicMock
 from mockito import when
 from twisted.internet import defer
-from twisted.trial import unittest
 from pixelated.config.sessions import LeapSession, SessionCache
 from pixelated.bitmask_libraries.keymanager import UploadKeyError
 
@@ -44,8 +42,9 @@ class SessionTest(AbstractLeapTest):
                 yield session.first_required_sync()
                 mail_fetcher_mock.startService.assert_called_once()
 
+    @patch('pixelated.config.sessions.register')
     @defer.inlineCallbacks
-    def test_upload_key_error_closes_the_session(self):
+    def test_upload_key_error_closes_the_session(self, _):
         when(self.keymanager).generate_openpgp_key().thenRaise(UploadKeyError('Could not upload key'))
         session = self._create_session()
         session.close = MagicMock()

--- a/service/test/unit/config/test_sessions.py
+++ b/service/test/unit/config/test_sessions.py
@@ -17,9 +17,11 @@
 import os
 from mock import patch
 from mock import MagicMock
+from mockito import when
 from twisted.internet import defer
 from twisted.trial import unittest
 from pixelated.config.sessions import LeapSession, SessionCache
+from pixelated.bitmask_libraries.keymanager import UploadKeyError
 
 from test.unit.bitmask_libraries.test_abstract_leap import AbstractLeapTest
 from leap.common.events.catalog import KEYMANAGER_FINISHED_KEY_GENERATION
@@ -41,6 +43,16 @@ class SessionTest(AbstractLeapTest):
                 session = self._create_session()
                 yield session.first_required_sync()
                 mail_fetcher_mock.startService.assert_called_once()
+
+    @defer.inlineCallbacks
+    def test_upload_key_error_closes_the_session(self):
+        when(self.keymanager).generate_openpgp_key().thenRaise(UploadKeyError('Could not upload key'))
+        session = self._create_session()
+        session.close = MagicMock()
+
+        with self.assertRaises(UploadKeyError):
+            yield session.finish_bootstrap()
+            session.close.assert_called_once()
 
     @patch('pixelated.config.sessions.register')
     @patch('pixelated.config.sessions.unregister')


### PR DESCRIPTION
When the upload of the user key fails (i.e. Timeout), the session was being held
in memory, preventing the user from trying again.

Related with: #815, #889