### PR TITLE
Remove python-gnupg debian package as dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ X-Python-Version: >= 2.7
 
 Package: pixelated-user-agent
 Architecture: all
-Depends: python (>= 2.7), python (<< 2.8), libffi6, python-gnupg
+Depends: python (>= 2.7), python (<< 2.8), libffi6
 Description: API to serve the pixelated front-end requests
  Pixelated User Agent Service
  ============================


### PR DESCRIPTION
We're having issues with python-gnupg when we are creating the image for piuparts testing.

```
17:14:45.477   The following extra packages will be installed:
17:14:45.477     python-gnupg
17:14:45.477   The following NEW packages will be installed:
17:14:45.477     python-gnupg
17:14:45.477   0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
17:14:45.477   1 not fully installed or removed.
17:14:45.477   Need to get 14.7 kB of archives.
17:14:45.478   After this operation, 92.2 kB of additional disk space will be used.
17:14:45.478   Err http://debian.mirror.iphh.net/debian/ jessie/main python-gnupg all 0.3.6-1
17:14:45.478     Could not connect to 213.73.97.49:3142 (213.73.97.49), connection timed out
17:14:45.478   E: Failed to fetch http://debian.mirror.iphh.net/debian/pool/main/p/python-gnupg/python-gnupg_0.3.6-1_all.deb  Could not connect to 213.73.97.49:3142 (213.73.97.49), connection timed out
```

Since we believe we are not using python-gnupg as a debian package, we are suggesting to remove it.