### PR TITLE
Make registering of events for fresh accounts a bit more robust by re…

### DIFF
--- a/service/pixelated/config/sessions.py
+++ b/service/pixelated/config/sessions.py
@@ -154,7 +154,7 @@ class LeapSession(object):
         self.account = None
         self._has_been_initially_synced = False
         self._is_closed = False
-        register(events.KEYMANAGER_FINISHED_KEY_GENERATION, self._set_fresh_account, uid=self.account_email())
+        register(events.KEYMANAGER_FINISHED_KEY_GENERATION, self._set_fresh_account, uid=self.account_email(), replace=True)
 
     @defer.inlineCallbacks
     def first_required_sync(self):

--- a/service/test/unit/config/test_sessions.py
+++ b/service/test/unit/config/test_sessions.py
@@ -74,13 +74,12 @@ class SessionTest(AbstractLeapTest):
         yield session.sync()
         self.soledad_session.sync.assert_called_once()
 
-    def test_session_registers_to_generated_keys(self):
+    @patch('pixelated.config.sessions.register')
+    def test_session_registers_to_generated_keys(self, register_mock):
         email = 'someone@somedomain.tld'
         self.provider.address_for.return_value = email
-        with patch('pixelated.config.sessions.register') as register_mock:
-            session = self._create_session()
-
-            register_mock.assert_called_once_with(KEYMANAGER_FINISHED_KEY_GENERATION, session._set_fresh_account, uid=email)
+        session = self._create_session()
+        register_mock.assert_called_once_with(KEYMANAGER_FINISHED_KEY_GENERATION, session._set_fresh_account, uid=email, replace=True)
 
     @patch('pixelated.config.sessions.register')
     def test_close_unregisters_from_generate_keys_events(self, _):


### PR DESCRIPTION
…placing the old events if they were not cleaned up after previous errors

This fixes #889 