### PR TITLE
Keep exception context

### DIFF
--- a/service/pixelated/config/leap.py
+++ b/service/pixelated/config/leap.py
@@ -99,7 +99,7 @@ class BootstrapUserServices(object):
             log.warn('{0}: {1}. Closing session for user: {2}'.format(e.__class__.__name__, e, user_auth.username))
             if leap_session:
                 leap_session.close()
-            raise e
+            raise
 
     @defer.inlineCallbacks
     def _setup_user_services(self, leap_session):

--- a/service/pixelated/config/sessions.py
+++ b/service/pixelated/config/sessions.py
@@ -18,9 +18,7 @@ from __future__ import absolute_import
 
 import os
 import errno
-import traceback
 import requests
-import sys
 
 from twisted.internet import defer, threads, reactor
 from twisted.logger import Logger
@@ -35,10 +33,9 @@ from leap.common.events import (
     catalog as events
 )
 
-from pixelated.bitmask_libraries.keymanager import Keymanager, UploadKeyError
+from pixelated.bitmask_libraries.keymanager import Keymanager
 from pixelated.adapter.mailstore import LeapMailStore
 from pixelated.config import leap_config
-from pixelated.bitmask_libraries.certs import LeapCertificate
 from pixelated.bitmask_libraries.smtp import LeapSMTPConfig
 
 logger = Logger()

--- a/service/test/unit/config/test_leap.py
+++ b/service/test/unit/config/test_leap.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
 
-from leap.soledad.common.errors import InvalidAuthTokenError
 from mock import MagicMock, patch, Mock
 from twisted.trial import unittest
 from twisted.internet import defer
@@ -170,7 +169,7 @@ class TestUserBootstrap(unittest.TestCase):
     @patch('pixelated.config.leap.create_leap_session')
     @patch('pixelated.config.leap.log.warn')
     @defer.inlineCallbacks
-    def test__setup__should_close_leap_sesson_on_error_from__setup_user_services(self, mock_logger_warn, mock_create_leap_session, mock_setup_user_services):
+    def test__setup__should_close_leap_session_on_error_from__setup_user_services(self, mock_logger_warn, mock_create_leap_session, mock_setup_user_services):
         leap_session = Mock()
         leap_session.close = Mock()
         mock_create_leap_session.return_value = leap_session
@@ -184,7 +183,7 @@ class TestUserBootstrap(unittest.TestCase):
     @patch('pixelated.config.leap.create_leap_session')
     @patch('pixelated.config.leap.log.warn')
     @defer.inlineCallbacks
-    def test__setup__should_close_leap_sesson_on_error_from__add_welcome_email(self, mock_logger_warn, mock_create_leap_session, _, mock_add_welcome_email):
+    def test__setup__should_close_leap_session_on_error_from__add_welcome_email(self, mock_logger_warn, mock_create_leap_session, _, mock_add_welcome_email):
         leap_session = Mock()
         leap_session.close = Mock()
         mock_create_leap_session.return_value = leap_session

--- a/service/test/unit/config/test_sessions.py
+++ b/service/test/unit/config/test_sessions.py
@@ -17,10 +17,8 @@
 
 from mock import patch
 from mock import MagicMock
-from mockito import when
 from twisted.internet import defer
 from pixelated.config.sessions import LeapSession, SessionCache, LeapSessionFactory, SoledadWrongPassphraseException
-from pixelated.bitmask_libraries.keymanager import UploadKeyError
 from test.unit.bitmask_libraries.test_abstract_leap import AbstractLeapTest
 from leap.common.events.catalog import KEYMANAGER_FINISHED_KEY_GENERATION
 from leap.soledad.common.crypto import WrongMacError, UnknownMacMethodError
@@ -42,17 +40,6 @@ class SessionTest(AbstractLeapTest):
                 session = self._create_session()
                 yield session.first_required_sync()
                 mail_fetcher_mock.startService.assert_called_once()
-
-    @patch('pixelated.config.sessions.register')
-    @defer.inlineCallbacks
-    def test_upload_key_error_closes_the_session(self, _):
-        when(self.keymanager).generate_openpgp_key().thenRaise(UploadKeyError('Could not upload key'))
-        session = self._create_session()
-        session.close = MagicMock()
-
-        with self.assertRaises(UploadKeyError):
-            yield session.finish_bootstrap()
-            session.close.assert_called_once()
 
     @patch('pixelated.config.sessions.register')
     @patch('pixelated.config.sessions.unregister')


### PR DESCRIPTION
Something I noticed while testing #889.
I changed `raise e` to `raise`, so we'll see the traceback where the exception started.