### PR TITLE
Adds postinstall scritp to restart pixelated-server

### DIFF
--- a/debian/pixelated-user-agent.postinst
+++ b/debian/pixelated-user-agent.postinst
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export PATH=/bin:/usr/bin:/sbin:/usr/sbin
+
+systemctl restart pixelated-server

--- a/debian/pixelated-user-agent.postinst
+++ b/debian/pixelated-user-agent.postinst
@@ -2,4 +2,6 @@
 
 export PATH=/bin:/usr/bin:/sbin:/usr/sbin
 
-systemctl restart pixelated-server
+if [ -d /run/systemd/system  ]; then
+  systemctl -q is-active pixelated-server.service && systemctl restart pixelated-server.service
+fi


### PR DESCRIPTION
After upgrading Pixelated User Agent package this script will restart the
server in order to have the newest code running.

This change makes explicit the relationship between pixelated-user-agent and pixelated-server.
It is not necessarily good, so we are planning to unify pixelated-service and pixelated-user-agent on the feature to make pixelated-user-agent as a service.
For now it will solve our current problem about restart pixelated-service after the pixelated-user-agent updated package.