### PR TITLE
[#924] Implements update recovery code through bitmask

### DIFF
--- a/service/pixelated/account_recovery.py
+++ b/service/pixelated/account_recovery.py
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
 from twisted.internet.defer import inlineCallbacks, returnValue
-import traceback
+from twisted.logger import Logger
+
+log = Logger()
 
 
 class AccountRecovery(object):
@@ -27,5 +29,5 @@ class AccountRecovery(object):
             response = yield self._session.update_recovery_code(recovery_code)
             returnValue(response)
         except Exception as e:
-            traceback.print_exc(e)
+            log.warn('Something went wrong when trying to save the recovery code')
             raise

--- a/service/pixelated/account_recovery.py
+++ b/service/pixelated/account_recovery.py
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2017 ThoughtWorks, Inc.
+#
+# Pixelated is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Pixelated is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+from twisted.internet.defer import inlineCallbacks, returnValue
+import traceback
+
+
+class AccountRecovery(object):
+    def __init__(self, session):
+        self._session = session
+
+    @inlineCallbacks
+    def update_recovery_code(self, recovery_code):
+        try:
+            response = yield self._session.update_recovery_code(recovery_code)
+            returnValue(response)
+        except Exception as e:
+            traceback.print_exc(e)
+            raise

--- a/service/pixelated/authentication.py
+++ b/service/pixelated/authentication.py
@@ -30,6 +30,7 @@ class Authenticator(object):
     def __init__(self, leap_provider):
         self._leap_provider = leap_provider
         self.domain = leap_provider.server_name
+        self.bonafide_sesssion = None
 
     @inlineCallbacks
     def authenticate(self, username, password):
@@ -49,9 +50,13 @@ class Authenticator(object):
     def _bonafide_auth(self, user, password):
         srp_provider = Api(self._leap_provider.api_uri)
         credentials = Credentials(user, password)
-        srp_auth = Session(credentials, srp_provider, self._leap_provider.local_ca_crt)
-        yield srp_auth.authenticate()
-        returnValue(Authentication(user, srp_auth.token, srp_auth.uuid, 'session_id', {'is_admin': False}))
+        self.bonafide_sesssion = Session(credentials, srp_provider, self._leap_provider.local_ca_crt)
+        yield self.bonafide_sesssion.authenticate()
+        returnValue(Authentication(user,
+                                   self.bonafide_sesssion.token,
+                                   self.bonafide_sesssion.uuid,
+                                   'session_id',
+                                   {'is_admin': False}))
 
     def clean_username(self, username):
         if '@' not in username:

--- a/service/pixelated/authentication.py
+++ b/service/pixelated/authentication.py
@@ -30,7 +30,7 @@ class Authenticator(object):
     def __init__(self, leap_provider):
         self._leap_provider = leap_provider
         self.domain = leap_provider.server_name
-        self.bonafide_sesssion = None
+        self.bonafide_session = None
 
     @inlineCallbacks
     def authenticate(self, username, password):
@@ -50,11 +50,11 @@ class Authenticator(object):
     def _bonafide_auth(self, user, password):
         srp_provider = Api(self._leap_provider.api_uri)
         credentials = Credentials(user, password)
-        self.bonafide_sesssion = Session(credentials, srp_provider, self._leap_provider.local_ca_crt)
-        yield self.bonafide_sesssion.authenticate()
+        self.bonafide_session = Session(credentials, srp_provider, self._leap_provider.local_ca_crt)
+        yield self.bonafide_session.authenticate()
         returnValue(Authentication(user,
-                                   self.bonafide_sesssion.token,
-                                   self.bonafide_sesssion.uuid,
+                                   self.bonafide_session.token,
+                                   self.bonafide_session.uuid,
                                    'session_id',
                                    {'is_admin': False}))
 

--- a/service/pixelated/resources/backup_account_resource.py
+++ b/service/pixelated/resources/backup_account_resource.py
@@ -49,7 +49,7 @@ class BackupAccountResource(BaseResource):
         return renderElement(request, site)
 
     def render_POST(self, request):
-        account_recovery = AccountRecovery(self._authenticator.bonafide_sesssion)
+        account_recovery = AccountRecovery(self._authenticator.bonafide_session)
 
         def update_response(response):
             request.setResponseCode(NO_CONTENT)

--- a/service/pixelated/resources/backup_account_resource.py
+++ b/service/pixelated/resources/backup_account_resource.py
@@ -20,7 +20,9 @@ from xml.sax import SAXParseException
 from pixelated.resources import BaseResource
 from twisted.python.filepath import FilePath
 from pixelated.resources import get_protected_static_folder
-from twisted.web.http import OK
+from pixelated.account_recovery import AccountRecovery
+from twisted.web.http import OK, NO_CONTENT, INTERNAL_SERVER_ERROR
+from twisted.web.server import NOT_DONE_YET
 from twisted.web.template import Element, XMLFile, renderElement
 
 
@@ -34,8 +36,9 @@ class BackupAccountPage(Element):
 class BackupAccountResource(BaseResource):
     isLeaf = True
 
-    def __init__(self, services_factory):
+    def __init__(self, services_factory, authenticator):
         BaseResource.__init__(self, services_factory)
+        self._authenticator = authenticator
 
     def render_GET(self, request):
         request.setResponseCode(OK)
@@ -44,3 +47,19 @@ class BackupAccountResource(BaseResource):
     def _render_template(self, request):
         site = BackupAccountPage()
         return renderElement(request, site)
+
+    def render_POST(self, request):
+        account_recovery = AccountRecovery(self._authenticator.bonafide_sesssion)
+
+        def update_response(response):
+            request.setResponseCode(NO_CONTENT)
+            request.finish()
+
+        def error_response(response):
+            request.setResponseCode(INTERNAL_SERVER_ERROR)
+            request.finish()
+
+        d = account_recovery.update_recovery_code("123")
+        d.addCallbacks(update_response)
+        d.addErrback(error_response)
+        return NOT_DONE_YET

--- a/service/pixelated/resources/backup_account_resource.py
+++ b/service/pixelated/resources/backup_account_resource.py
@@ -60,6 +60,5 @@ class BackupAccountResource(BaseResource):
             request.finish()
 
         d = account_recovery.update_recovery_code("123")
-        d.addCallbacks(update_response)
-        d.addErrback(error_response)
+        d.addCallbacks(update_response, error_response)
         return NOT_DONE_YET

--- a/service/pixelated/resources/login_resource.py
+++ b/service/pixelated/resources/login_resource.py
@@ -86,7 +86,7 @@ class LoginResource(BaseResource):
         BaseResource.__init__(self, services_factory)
         self._disclaimer_banner = disclaimer_banner
         self._provider = provider
-        self._authenticator = authenticator or Authenticator(provider)
+        self._authenticator = authenticator
         self._bootstrap_user_services = BootstrapUserServices(services_factory, provider)
 
         static_folder = get_public_static_folder()

--- a/service/pixelated/resources/root_resource.py
+++ b/service/pixelated/resources/root_resource.py
@@ -91,7 +91,7 @@ class RootResource(BaseResource):
 
     def initialize(self, provider=None, disclaimer_banner=None, authenticator=None):
         self._child_resources.add('assets', File(self._protected_static_folder))
-        self._child_resources.add('backup-account', BackupAccountResource(self._services_factory))
+        self._child_resources.add('backup-account', BackupAccountResource(self._services_factory, authenticator))
         self._child_resources.add('sandbox', SandboxResource(self._protected_static_folder))
         self._child_resources.add('keys', KeysResource(self._services_factory))
         self._child_resources.add(AttachmentsResource.BASE_URL, AttachmentsResource(self._services_factory))

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -7,7 +7,7 @@ srp==1.0.6
 whoosh==2.6.0
 Twisted==16.1.1
 -e 'git+https://0xacab.org/leap/leap_pycommon.git@master#egg=leap.common'
--e 'git+https://0xacab.org/pixelated/bitmask-dev.git@feat_fetch_remote_on_expiry#egg=leap.bitmask'
+-e 'git+https://0xacab.org/pixelated/bitmask-dev.git@recovery-code-and-key-expiry#egg=leap.bitmask'
 -e 'git+https://0xacab.org/pixelated/soledad.git@master#egg=leap.soledad.common&subdirectory=common/'
 -e 'git+https://0xacab.org/pixelated/soledad.git@master#egg=leap.soledad.client&subdirectory=client/'
 -e .

--- a/service/test/unit/resources/test_backup_account_resource.py
+++ b/service/test/unit/resources/test_backup_account_resource.py
@@ -19,6 +19,7 @@ import os
 from mock import MagicMock, patch
 from twisted.trial import unittest
 from twisted.web.test.requesthelper import DummyRequest
+from twisted.internet import defer
 
 from pixelated.resources.backup_account_resource import BackupAccountResource
 from test.unit.resources import DummySite
@@ -27,7 +28,7 @@ from test.unit.resources import DummySite
 class TestBackupAccountResource(unittest.TestCase):
     def setUp(self):
         self.services_factory = MagicMock()
-        self.resource = BackupAccountResource(self.services_factory)
+        self.resource = BackupAccountResource(self.services_factory, MagicMock())
         self.web = DummySite(self.resource)
 
     def test_get(self):
@@ -40,4 +41,46 @@ class TestBackupAccountResource(unittest.TestCase):
             self.assertIn("DOCTYPE html", request.written[0])
 
         d.addCallback(assert_200_when_user_logged_in)
+        return d
+
+    @patch('pixelated.resources.backup_account_resource.AccountRecovery')
+    def test_post_updates_recovery_code(self, mock_account_recovery_init):
+        mock_account_recovery = MagicMock()
+        mock_account_recovery_init.return_value = mock_account_recovery
+        mock_account_recovery.update_recovery_code.return_value = defer.succeed("Success")
+        request = DummyRequest(['/backup-account'])
+        request.method = 'POST'
+        d = self.web.get(request)
+
+        def assert_update_recovery_code_called(_):
+            mock_account_recovery_init.assert_called_with(self.resource._authenticator.bonafide_sesssion)
+            mock_account_recovery.update_recovery_code.assert_called()
+
+        d.addCallback(assert_update_recovery_code_called)
+        return d
+
+    @patch('pixelated.resources.backup_account_resource.AccountRecovery.update_recovery_code')
+    def test_post_returns_successfully(self, mock_update_recovery_code):
+        mock_update_recovery_code.return_value = defer.succeed("Success")
+        request = DummyRequest(['/backup-account'])
+        request.method = 'POST'
+        d = self.web.get(request)
+
+        def assert_successful_response(_):
+            self.assertEqual(204, request.responseCode)
+
+        d.addCallback(assert_successful_response)
+        return d
+
+    @patch('pixelated.resources.backup_account_resource.AccountRecovery.update_recovery_code')
+    def test_post_returns_internal_server_error(self, mock_update_recovery_code):
+        mock_update_recovery_code.return_value = defer.fail(Exception)
+        request = DummyRequest(['/backup-account'])
+        request.method = 'POST'
+        d = self.web.get(request)
+
+        def assert_successful_response(_):
+            self.assertEqual(500, request.responseCode)
+
+        d.addCallback(assert_successful_response)
         return d

--- a/service/test/unit/resources/test_backup_account_resource.py
+++ b/service/test/unit/resources/test_backup_account_resource.py
@@ -53,7 +53,7 @@ class TestBackupAccountResource(unittest.TestCase):
         d = self.web.get(request)
 
         def assert_update_recovery_code_called(_):
-            mock_account_recovery_init.assert_called_with(self.resource._authenticator.bonafide_sesssion)
+            mock_account_recovery_init.assert_called_with(self.resource._authenticator.bonafide_session)
             mock_account_recovery.update_recovery_code.assert_called()
 
         d.addCallback(assert_update_recovery_code_called)

--- a/service/test/unit/test_account_recovery.py
+++ b/service/test/unit/test_account_recovery.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2017 ThoughtWorks, Inc.
+#
+# Pixelated is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Pixelated is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+
+from twisted.internet.defer import inlineCallbacks
+from twisted.trial import unittest
+
+from mock import patch, Mock
+
+from pixelated.account_recovery import AccountRecovery
+
+
+class AccountRecoveryTest(unittest.TestCase):
+
+    @inlineCallbacks
+    def test_update_recovery_code(self):
+        mock_session = Mock()
+        account_recovery = AccountRecovery(mock_session)
+
+        yield account_recovery.update_recovery_code('ABC')
+        mock_session.update_recovery_code.assert_called_once_with('ABC')

--- a/service/test/unit/test_authentication.py
+++ b/service/test/unit/test_authentication.py
@@ -77,6 +77,7 @@ class AuthenticatorTest(unittest.TestCase):
             self.assertEquals('username', resulting_auth.username)
             self.assertEquals('some_token', resulting_auth.token)
             self.assertEquals('some_uuid', resulting_auth.uuid)
+            self.assertEquals(mock_srp_auth, auth.bonafide_sesssion)
 
     def test_username_without_domain_is_not_changed(self):
         username_without_domain = 'username'

--- a/service/test/unit/test_authentication.py
+++ b/service/test/unit/test_authentication.py
@@ -77,7 +77,7 @@ class AuthenticatorTest(unittest.TestCase):
             self.assertEquals('username', resulting_auth.username)
             self.assertEquals('some_token', resulting_auth.token)
             self.assertEquals('some_uuid', resulting_auth.uuid)
-            self.assertEquals(mock_srp_auth, auth.bonafide_sesssion)
+            self.assertEquals(mock_srp_auth, auth.bonafide_session)
 
     def test_username_without_domain_is_not_changed(self):
         username_without_domain = 'username'


### PR DESCRIPTION
This is the first part of the Account Recovery implementation, to allow existing accounts to add a recovery code to recover the password. These changes are only to persist the recovery code in webapp. It's not yet possible to login with the recovery code.

We are using a new branch of bitmask dev while we wait for this MR: https://0xacab.org/leap/bitmask-dev/merge_requests/79

Related with: https://github.com/pixelated/pixelated-user-agent/issues/924

with @anikarni