### PR TITLE
Forgot password page

### DIFF
--- a/service/pixelated/resources/account_recovery_resource.py
+++ b/service/pixelated/resources/account_recovery_resource.py
@@ -15,7 +15,6 @@
 # along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from xml.sax import SAXParseException
 
 from pixelated.resources import BaseResource
 from twisted.python.filepath import FilePath

--- a/service/pixelated/resources/account_recovery_resource.py
+++ b/service/pixelated/resources/account_recovery_resource.py
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2017 ThoughtWorks, Inc.
+#
+# Pixelated is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Pixelated is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from xml.sax import SAXParseException
+
+from pixelated.resources import BaseResource
+from twisted.python.filepath import FilePath
+from pixelated.resources import get_protected_static_folder
+from twisted.web.http import OK
+from twisted.web.template import Element, XMLFile, renderElement
+
+
+class AccountRecoveryPage(Element):
+    loader = XMLFile(FilePath(os.path.join(get_protected_static_folder(), 'account_recovery.html')))
+
+    def __init__(self):
+        super(AccountRecoveryPage, self).__init__()
+
+
+class AccountRecoveryResource(BaseResource):
+    isLeaf = True
+
+    def __init__(self, services_factory):
+        BaseResource.__init__(self, services_factory)
+
+    def render_GET(self, request):
+        request.setResponseCode(OK)
+        return self._render_template(request)
+
+    def _render_template(self, request):
+        site = AccountRecoveryPage()
+        return renderElement(request, site)

--- a/service/pixelated/resources/root_resource.py
+++ b/service/pixelated/resources/root_resource.py
@@ -23,6 +23,7 @@ from pixelated.resources import BaseResource, UnAuthorizedResource, UnavailableR
 from pixelated.resources import get_public_static_folder, get_protected_static_folder
 from pixelated.resources.attachments_resource import AttachmentsResource
 from pixelated.resources.sandbox_resource import SandboxResource
+from pixelated.resources.account_recovery_resource import AccountRecoveryResource
 from pixelated.resources.backup_account_resource import BackupAccountResource
 from pixelated.resources.contacts_resource import ContactsResource
 from pixelated.resources.features_resource import FeaturesResource
@@ -91,6 +92,7 @@ class RootResource(BaseResource):
 
     def initialize(self, provider=None, disclaimer_banner=None, authenticator=None):
         self._child_resources.add('assets', File(self._protected_static_folder))
+        self._child_resources.add('account-recovery', AccountRecoveryResource(self._services_factory))
         self._child_resources.add('backup-account', BackupAccountResource(self._services_factory, authenticator))
         self._child_resources.add('sandbox', SandboxResource(self._protected_static_folder))
         self._child_resources.add('keys', KeysResource(self._services_factory))

--- a/service/test/unit/resources/test_account_recovery_resource.py
+++ b/service/test/unit/resources/test_account_recovery_resource.py
@@ -16,7 +16,7 @@
 
 import os
 
-from mock import MagicMock, patch
+from mock import MagicMock
 from twisted.trial import unittest
 from twisted.web.test.requesthelper import DummyRequest
 from twisted.internet import defer

--- a/service/test/unit/resources/test_account_recovery_resource.py
+++ b/service/test/unit/resources/test_account_recovery_resource.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2017 ThoughtWorks, Inc.
+#
+# Pixelated is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Pixelated is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from mock import MagicMock, patch
+from twisted.trial import unittest
+from twisted.web.test.requesthelper import DummyRequest
+from twisted.internet import defer
+
+from pixelated.resources.account_recovery_resource import AccountRecoveryResource
+from test.unit.resources import DummySite
+
+
+class TestAccountRecoveryResource(unittest.TestCase):
+    def setUp(self):
+        self.services_factory = MagicMock()
+        self.resource = AccountRecoveryResource(self.services_factory)
+        self.web = DummySite(self.resource)
+
+    def test_get(self):
+        request = DummyRequest(['/account-recovery'])
+        request.method = 'GET'
+        d = self.web.get(request)
+
+        def assert_200_when_user_logged_in(_):
+            self.assertEqual(200, request.responseCode)
+            self.assertIn("DOCTYPE html", request.written[0])
+
+        d.addCallback(assert_200_when_user_logged_in)
+        return d

--- a/web-ui/app/locales/en_US/translation.json
+++ b/web-ui/app/locales/en_US/translation.json
@@ -81,6 +81,9 @@
         "all": "All",
         "tags": "Tags"
     },
+    "account-recovery": {
+      "page-title": "Pixelated Account Recovery"
+    },
     "backup-account": {
       "page-title": "Pixelated Backup Account",
       "backup-email": {

--- a/web-ui/app/locales/pt_BR/translation.json
+++ b/web-ui/app/locales/pt_BR/translation.json
@@ -81,6 +81,9 @@
         "all": "Todas",
         "tags": "Etiquetas"
     },
+    "account-recovery": {
+      "page-title": "Pixelated Recuperação de Conta"
+    },
     "backup-account": {
       "page-title": "Pixelated E-mail de Recuperação",
       "backup-email": {

--- a/web-ui/config/protected-assets-webpack.js
+++ b/web-ui/config/protected-assets-webpack.js
@@ -5,6 +5,7 @@ module.exports = new CopyWebpackPlugin([
   { context: 'app/', from: 'index.html' },
   { context: 'app/', from: 'sandbox.html' },
   { context: 'app/', from: 'css/*' },
+  { context: 'src/account_recovery/', from: 'account_recovery.html' },
   { context: 'src/backup_account/', from: 'backup_account.html' },
   { context: 'app/bower_components/font-awesome/', from: 'fonts/*' },
   { context: 'app/bower_components/font-awesome/', from: 'css/font-awesome.min.css', to: 'css' },

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -20,7 +20,7 @@
     "dompurify": "0.8.4",
     "enzyme": "2.7.1",
     "es6-promise": "4.1.0",
-    "eslint": "3.17.1",
+    "eslint": "3.18.0",
     "eslint-config-airbnb": "14.1.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "4.0.0",

--- a/web-ui/src/account_recovery/account_recovery.html
+++ b/web-ui/src/account_recovery/account_recovery.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="icon" type="image/png" href="public/images/favicon.png" />
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
+    <title>Pixelated</title>
+  </head>
+  <body>
+    <div id="root"/>
+    <script type="text/javascript" src="/assets/account_recovery.js"></script>
+  </body>
+</html>

--- a/web-ui/src/account_recovery/account_recovery.js
+++ b/web-ui/src/account_recovery/account_recovery.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 ThoughtWorks, Inc.
+ *
+ * Pixelated is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pixelated is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { render } from 'react-dom';
+import a11y from 'react-a11y';
+
+import App from 'src/common/app';
+import PageWrapper from './page';
+
+require('es6-promise').polyfill();
+
+if (process.env.NODE_ENV === 'development') a11y(React);
+
+render(
+  <App child={<PageWrapper />} />,
+  document.getElementById('root')
+);

--- a/web-ui/src/account_recovery/page.js
+++ b/web-ui/src/account_recovery/page.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017 ThoughtWorks, Inc.
+ *
+ * Pixelated is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pixelated is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { translate } from 'react-i18next';
+import DocumentTitle from 'react-document-title';
+import Footer from 'src/common/footer/footer';
+import Header from 'src/common/header/header';
+
+import 'font-awesome/scss/font-awesome.scss';
+import './page.scss';
+
+
+export const Page = ({ t }) => (
+  <DocumentTitle title={t('account-recovery.page-title')}>
+    <div className='page'>
+      <Header />
+      <section />
+      <Footer />
+    </div>
+  </DocumentTitle>
+);
+
+Page.propTypes = {
+  t: React.PropTypes.func.isRequired
+};
+
+export default translate('', { wait: true })(Page);

--- a/web-ui/src/account_recovery/page.scss
+++ b/web-ui/src/account_recovery/page.scss
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 ThoughtWorks, Inc.
+ *
+ * Pixelated is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pixelated is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@import "~scss/vendor/reset";
+@import "~scss/base/colors";
+@import "~scss/base/fonts";
+
+html, body, #root {
+  height: 100%;
+}
+
+body, #root {
+  min-height: 100%;
+}
+
+a {
+  text-decoration: none;
+}
+
+.container {
+  background: $white;
+  margin: 3% auto;
+  box-shadow: 0 2px 3px 0 $shadow;
+}
+
+.page {
+  font-family: "Open Sans", "Microsoft YaHei", "Hiragino Sans GB", "Hiragino Sans GB W3", "微软雅黑", "Helvetica Neue", Arial, sans-serif;
+  background: $dark_blue; /* For browsers that do not support gradients */
+  background: -webkit-linear-gradient(left top, $dark_blue, $middle_blue); /* For Safari 5.1 to 6.0 */
+  background: -o-linear-gradient(bottom right, $dark_blue, $middle_blue); /* For Opera 11.1 to 12.0 */
+  background: -moz-linear-gradient(bottom right, $dark_blue, $middle_blue); /* For Firefox 3.6 to 15 */
+  background: linear-gradient(to bottom right, $dark_blue, $middle_blue); /* Standard syntax */
+  color: $dark_grey_text;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+section {
+  flex: 1 0 auto;
+}
+
+h1 {
+  font-size: 1.3em;
+  font-weight: 600;
+}
+
+p {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.link {
+  color: $dark_blue;
+  font-style: italic;
+  font-size: 0.8em;
+
+  .fa {
+    font-size: 1.6em;
+    position: relative;
+    top: 3px;
+    margin-right: 0.3em;
+  }
+
+}
+
+@media only screen and (min-width : 500px) {
+  body {
+    font-size: 1.3em;
+  }
+}

--- a/web-ui/src/account_recovery/page.spec.js
+++ b/web-ui/src/account_recovery/page.spec.js
@@ -1,0 +1,17 @@
+import { shallow } from 'enzyme';
+import expect from 'expect';
+import React from 'react';
+import { Page } from 'src/account_recovery/page';
+
+describe('Account Recovery Page', () => {
+  let page;
+
+  beforeEach(() => {
+    const mockTranslations = key => key;
+    page = shallow(<Page t={mockTranslations} />);
+  });
+
+  it('renders account recovery page title', () => {
+    expect(page.props().title).toEqual('account-recovery.page-title');
+  });
+});

--- a/web-ui/test/integration/translations.spec.js
+++ b/web-ui/test/integration/translations.spec.js
@@ -2,11 +2,19 @@ import { mount } from 'enzyme';
 import expect from 'expect';
 import React from 'react';
 import App from 'src/common/app';
+import AccountRecoveryPage from 'src/account_recovery/page';
 import BackupAccountPage from 'src/backup_account/page';
 import LoginPage from 'src/login/page';
 import testI18n from './i18n';
 
 describe('Translations', () => {
+  context('Account Recovery Page', () => {
+    it('translates all key', () => {
+      const app = mount(<App i18n={testI18n} child={<AccountRecoveryPage />} />);
+      expect(app.text()).toNotContain('untranslated', 'Unstranslated message found in the text: ' + app.text());
+    });
+  });
+
   context('Backup Account Page', () => {
     it('translates all key', () => {
       const app = mount(<App i18n={testI18n} child={<BackupAccountPage />} />);

--- a/web-ui/webpack.config.js
+++ b/web-ui/webpack.config.js
@@ -39,6 +39,7 @@ var publicAssets = Object.assign({}, commonConfiguration, {
 var protectedAssets = Object.assign({}, commonConfiguration, {
   entry: {
     'app': './app/js/index.js',
+    'account_recovery': './src/account_recovery/account_recovery.js',
     'backup_account': './src/backup_account/backup_account.js',
     'sandbox': './app/js/sandbox.js'
   },

--- a/web-ui/webpack.production.config.js
+++ b/web-ui/webpack.production.config.js
@@ -43,6 +43,7 @@ var publicAssets = Object.assign({}, commonConfiguration, {
 var protectedAssets = Object.assign({}, commonConfiguration, {
   entry: {
     'app': './app/js/index.js',
+    'account_recovery': './src/account_recovery/account_recovery.js',
     'backup_account': './src/backup_account/backup_account.js',
     'sandbox': './app/js/sandbox.js'
   },


### PR DESCRIPTION
This PR creates the resource for the forgot password page, but does not implement anything on the page yet (just the header and footer, as bellow).

<img width="1392" alt="screen shot 2017-03-27 at 13 59 58" src="https://cloud.githubusercontent.com/assets/7905650/24368153/c11a37d8-12f5-11e7-9182-2e2b47f71ef3.png">

Related with #932 

