### PR TITLE
Adds admin code form and logic for next step of recovery form

### DIFF
--- a/web-ui/app/locales/en_US/translation.json
+++ b/web-ui/app/locales/en_US/translation.json
@@ -82,7 +82,15 @@
         "tags": "Tags"
     },
     "account-recovery": {
-      "page-title": "Pixelated Account Recovery"
+      "page-title": "Pixelated Account Recovery",
+      "admin-form": {
+        "title": "Contact your account administrator and ask for their part of the recovery code",
+        "tip1": "The safest way to do this is in person.",
+        "tip2": "You can call or text if you need to.",
+        "tip3": "Don't ever ask for it via email.",
+        "input-label": "type here admin's backup code",
+        "button": "Next"
+      }
     },
     "backup-account": {
       "page-title": "Pixelated Backup Account",

--- a/web-ui/app/locales/en_US/translation.json
+++ b/web-ui/app/locales/en_US/translation.json
@@ -90,6 +90,9 @@
         "tip3": "Don't ever ask for it via email.",
         "input-label": "type here admin's backup code",
         "button": "Next"
+      },
+      "user-form": {
+        "title": "Remember your backup account?"
       }
     },
     "backup-account": {

--- a/web-ui/src/account_recovery/forms/admin_recovery_code_form.js
+++ b/web-ui/src/account_recovery/forms/admin_recovery_code_form.js
@@ -25,7 +25,7 @@ import './admin_recovery_code_form.scss';
 
 
 export const AdminRecoveryCodeForm = ({ t, next }) => (
-  <form onSubmit={next}>
+  <form className='admin-code-form' onSubmit={next}>
     <h1>{t('account-recovery.admin-form.title')}</h1>
     <ul>
       <li>{t('account-recovery.admin-form.tip1')}</li>

--- a/web-ui/src/account_recovery/forms/admin_recovery_code_form.js
+++ b/web-ui/src/account_recovery/forms/admin_recovery_code_form.js
@@ -24,8 +24,8 @@ import SubmitButton from 'src/common/submit_button/submit_button';
 import './admin_recovery_code_form.scss';
 
 
-export const AdminRecoveryCodeForm = ({ t }) => (
-  <div>
+export const AdminRecoveryCodeForm = ({ t, next }) => (
+  <form onSubmit={next}>
     <h1>{t('account-recovery.admin-form.title')}</h1>
     <ul>
       <li>{t('account-recovery.admin-form.tip1')}</li>
@@ -34,11 +34,12 @@ export const AdminRecoveryCodeForm = ({ t }) => (
     </ul>
     <InputField name='admin-code' label={t('account-recovery.admin-form.input-label')} />
     <SubmitButton buttonText={t('account-recovery.admin-form.button')} />
-  </div>
+  </form>
 );
 
 AdminRecoveryCodeForm.propTypes = {
-  t: React.PropTypes.func.isRequired
+  t: React.PropTypes.func.isRequired,
+  next: React.PropTypes.func.isRequired
 };
 
 export default translate('', { wait: true })(AdminRecoveryCodeForm);

--- a/web-ui/src/account_recovery/forms/admin_recovery_code_form.js
+++ b/web-ui/src/account_recovery/forms/admin_recovery_code_form.js
@@ -17,31 +17,28 @@
 
 import React from 'react';
 import { translate } from 'react-i18next';
-import DocumentTitle from 'react-document-title';
-import Header from 'src/common/header/header';
-import AdminRecoveryCodeForm from 'src/account_recovery/forms/admin_recovery_code_form';
-import Footer from 'src/common/footer/footer';
 
-import 'font-awesome/scss/font-awesome.scss';
-import './page.scss';
+import InputField from 'src/common/input_field/input_field';
+import SubmitButton from 'src/common/submit_button/submit_button';
+
+import './admin_recovery_code_form.scss';
 
 
-export const Page = ({ t }) => (
-  <DocumentTitle title={t('account-recovery.page-title')}>
-    <div className='page'>
-      <Header />
-      <section>
-        <div className='container'>
-          <AdminRecoveryCodeForm />
-        </div>
-      </section>
-      <Footer />
-    </div>
-  </DocumentTitle>
+export const AdminRecoveryCodeForm = ({ t }) => (
+  <div>
+    <h1>{t('account-recovery.admin-form.title')}</h1>
+    <ul>
+      <li>{t('account-recovery.admin-form.tip1')}</li>
+      <li>{t('account-recovery.admin-form.tip2')}</li>
+      <li>{t('account-recovery.admin-form.tip3')}</li>
+    </ul>
+    <InputField name='admin-code' label={t('account-recovery.admin-form.input-label')} />
+    <SubmitButton buttonText={t('account-recovery.admin-form.button')} />
+  </div>
 );
 
-Page.propTypes = {
+AdminRecoveryCodeForm.propTypes = {
   t: React.PropTypes.func.isRequired
 };
 
-export default translate('', { wait: true })(Page);
+export default translate('', { wait: true })(AdminRecoveryCodeForm);

--- a/web-ui/src/account_recovery/forms/admin_recovery_code_form.spec.js
+++ b/web-ui/src/account_recovery/forms/admin_recovery_code_form.spec.js
@@ -1,0 +1,29 @@
+import { shallow } from 'enzyme';
+import expect from 'expect';
+import React from 'react';
+import { AdminRecoveryCodeForm } from 'src/account_recovery/forms/admin_recovery_code_form';
+
+describe('AdminRecoveryCodeForm', () => {
+  let adminRecoveryCodeForm;
+
+  beforeEach(() => {
+    const mockTranslations = key => key;
+    adminRecoveryCodeForm = shallow(<AdminRecoveryCodeForm t={mockTranslations} />);
+  });
+
+  it('renders title for admin recovery code', () => {
+    expect(adminRecoveryCodeForm.find('h1').text()).toEqual('account-recovery.admin-form.title');
+  });
+
+  it('renders tips for retrieving recovery code', () => {
+    expect(adminRecoveryCodeForm.find('li').length).toEqual(3);
+  });
+
+  it('renders input field for admin code', () => {
+    expect(adminRecoveryCodeForm.find('InputField').props().name).toEqual('admin-code');
+  });
+
+  it('renders button for next step', () => {
+    expect(adminRecoveryCodeForm.find('SubmitButton').props().buttonText).toEqual('account-recovery.admin-form.button');
+  });
+});

--- a/web-ui/src/account_recovery/forms/admin_recovery_code_form.spec.js
+++ b/web-ui/src/account_recovery/forms/admin_recovery_code_form.spec.js
@@ -5,10 +5,14 @@ import { AdminRecoveryCodeForm } from 'src/account_recovery/forms/admin_recovery
 
 describe('AdminRecoveryCodeForm', () => {
   let adminRecoveryCodeForm;
+  let mockNext;
 
   beforeEach(() => {
     const mockTranslations = key => key;
-    adminRecoveryCodeForm = shallow(<AdminRecoveryCodeForm t={mockTranslations} />);
+    mockNext = expect.createSpy();
+    adminRecoveryCodeForm = shallow(
+      <AdminRecoveryCodeForm t={mockTranslations} next={mockNext} />
+    );
   });
 
   it('renders title for admin recovery code', () => {
@@ -25,5 +29,10 @@ describe('AdminRecoveryCodeForm', () => {
 
   it('renders button for next step', () => {
     expect(adminRecoveryCodeForm.find('SubmitButton').props().buttonText).toEqual('account-recovery.admin-form.button');
+  });
+
+  it('submits form to next step', () => {
+    adminRecoveryCodeForm.find('form').simulate('submit');
+    expect(mockNext).toHaveBeenCalled();
   });
 });

--- a/web-ui/src/account_recovery/forms/user_recovery_code_form.js
+++ b/web-ui/src/account_recovery/forms/user_recovery_code_form.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017 ThoughtWorks, Inc.
+ *
+ * Pixelated is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pixelated is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { translate } from 'react-i18next';
+
+export const UserRecoveryCodeForm = ({ t }) => (
+  <form>
+    <h1>{t('account-recovery.user-form.title')}</h1>
+  </form>
+);
+
+UserRecoveryCodeForm.propTypes = {
+  t: React.PropTypes.func.isRequired
+};
+
+export default translate('', { wait: true })(UserRecoveryCodeForm);

--- a/web-ui/src/account_recovery/forms/user_recovery_code_form.spec.js
+++ b/web-ui/src/account_recovery/forms/user_recovery_code_form.spec.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import expect from 'expect';
+import React from 'react';
+import { UserRecoveryCodeForm } from 'src/account_recovery/forms/user_recovery_code_form';
+
+describe('UserRecoveryCodeForm', () => {
+  let userRecoveryCodeForm;
+
+  beforeEach(() => {
+    const mockTranslations = key => key;
+    userRecoveryCodeForm = shallow(
+      <UserRecoveryCodeForm t={mockTranslations} />
+    );
+  });
+
+  it('renders title for user recovery code', () => {
+    expect(userRecoveryCodeForm.find('h1').text()).toEqual('account-recovery.user-form.title');
+  });
+});

--- a/web-ui/src/account_recovery/page.js
+++ b/web-ui/src/account_recovery/page.js
@@ -20,25 +20,49 @@ import { translate } from 'react-i18next';
 import DocumentTitle from 'react-document-title';
 import Header from 'src/common/header/header';
 import AdminRecoveryCodeForm from 'src/account_recovery/forms/admin_recovery_code_form';
+import UserRecoveryCodeForm from 'src/account_recovery/forms/user_recovery_code_form';
 import Footer from 'src/common/footer/footer';
 
 import 'font-awesome/scss/font-awesome.scss';
 import './page.scss';
 
 
-export const Page = ({ t }) => (
-  <DocumentTitle title={t('account-recovery.page-title')}>
-    <div className='page'>
-      <Header />
-      <section>
-        <div className='container'>
-          <AdminRecoveryCodeForm />
+export class Page extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { step: 0 };
+  }
+
+  nextStep = (event) => {
+    event.preventDefault();
+    this.setState({ step: this.state.step + 1 });
+  }
+
+  steps = {
+    0: <AdminRecoveryCodeForm next={this.nextStep} />,
+    1: <UserRecoveryCodeForm />
+  }
+
+  mainContent = () => this.steps[this.state.step];
+
+  render() {
+    const t = this.props.t;
+    return (
+      <DocumentTitle title={t('account-recovery.page-title')}>
+        <div className='page'>
+          <Header />
+          <section>
+            <div className='container'>
+              {this.mainContent()}
+            </div>
+          </section>
+          <Footer />
         </div>
-      </section>
-      <Footer />
-    </div>
-  </DocumentTitle>
-);
+      </DocumentTitle>
+    );
+  }
+}
 
 Page.propTypes = {
   t: React.PropTypes.func.isRequired

--- a/web-ui/src/account_recovery/page.scss
+++ b/web-ui/src/account_recovery/page.scss
@@ -35,6 +35,8 @@ a {
   background: $white;
   margin: 3% auto;
   box-shadow: 0 2px 3px 0 $shadow;
+  width: 84%;
+  padding: 6% 5%;
 }
 
 .page {

--- a/web-ui/src/account_recovery/page.spec.js
+++ b/web-ui/src/account_recovery/page.spec.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { Page } from 'src/account_recovery/page';
 import Header from 'src/common/header/header';
 import AdminRecoveryCodeForm from 'src/account_recovery/forms/admin_recovery_code_form';
+import UserRecoveryCodeForm from 'src/account_recovery/forms/user_recovery_code_form';
 import Footer from 'src/common/footer/footer';
 
 describe('Account Recovery Page', () => {
@@ -23,11 +24,26 @@ describe('Account Recovery Page', () => {
     expect(page.find(Header).length).toEqual(1);
   });
 
-  it('renders admin recovery code form', () => {
-    expect(page.find(AdminRecoveryCodeForm).length).toEqual(1);
-  });
-
   it('renders footer', () => {
     expect(page.find(Footer).length).toEqual(1);
+  });
+
+  context('main content', () => {
+    let pageInstance;
+
+    beforeEach(() => {
+      pageInstance = page.instance();
+    });
+
+    it('renders admin recovery code form as default form', () => {
+      expect(page.find(AdminRecoveryCodeForm).length).toEqual(1);
+    });
+
+    it('renders user recovery code form when admin code submitted', () => {
+      pageInstance.nextStep({ preventDefault: () => {} });
+
+      expect(page.find(AdminRecoveryCodeForm).length).toEqual(0);
+      expect(page.find(UserRecoveryCodeForm).length).toEqual(1);
+    });
   });
 });

--- a/web-ui/src/account_recovery/page.spec.js
+++ b/web-ui/src/account_recovery/page.spec.js
@@ -1,7 +1,11 @@
 import { shallow } from 'enzyme';
 import expect from 'expect';
 import React from 'react';
+
 import { Page } from 'src/account_recovery/page';
+import Header from 'src/common/header/header';
+import AdminRecoveryCodeForm from 'src/account_recovery/forms/admin_recovery_code_form';
+import Footer from 'src/common/footer/footer';
 
 describe('Account Recovery Page', () => {
   let page;
@@ -13,5 +17,17 @@ describe('Account Recovery Page', () => {
 
   it('renders account recovery page title', () => {
     expect(page.props().title).toEqual('account-recovery.page-title');
+  });
+
+  it('renders header', () => {
+    expect(page.find(Header).length).toEqual(1);
+  });
+
+  it('renders admin recovery code form', () => {
+    expect(page.find(AdminRecoveryCodeForm).length).toEqual(1);
+  });
+
+  it('renders footer', () => {
+    expect(page.find(Footer).length).toEqual(1);
   });
 });

--- a/web-ui/test/integration/translations.spec.js
+++ b/web-ui/test/integration/translations.spec.js
@@ -9,8 +9,15 @@ import testI18n from './i18n';
 
 describe('Translations', () => {
   context('Account Recovery Page', () => {
-    it('translates all key', () => {
+    it('translates all keys on first step', () => {
       const app = mount(<App i18n={testI18n} child={<AccountRecoveryPage />} />);
+      expect(app.text()).toNotContain('untranslated', 'Unstranslated message found in the text: ' + app.text());
+    });
+
+    it('translates all keys on second step', () => {
+      const app = mount(<App i18n={testI18n} child={<AccountRecoveryPage />} />);
+      app.find('form.admin-code-form').simulate('submit');
+
       expect(app.text()).toNotContain('untranslated', 'Unstranslated message found in the text: ' + app.text());
     });
   });


### PR DESCRIPTION
So far, the admin code form is displayed on loading page, and, when clicking next, it show the title for the next form (see gif bellow).

TODO:
- [ ] Translate to portuguese
- [ ] Add progress bar
- [ ] Fix desktop version
- [ ] Add user recovery code form

![acc-rec-gif](https://cloud.githubusercontent.com/assets/7905650/24411689/dc7cdbf4-13ac-11e7-9adf-12e4be8f7c92.gif)
