### PR TITLE
[#1018] Upgrades twisted from 16.1.1 to 17.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ linters_js:
 coverage:
 	@. $(VIRTUALENV)/bin/activate;\
 	cd service;\
+	export PYTHONPATH=$(PYTHONPATH):`pwd`;\
 	coverage run -p --source=pixelated `which trial` test.unit;\
 	coverage run -p --source=pixelated `which trial` test.integration;\
 	coverage combine;\
@@ -62,6 +63,7 @@ coverage:
 unit_tests_py:
 	@. $(VIRTUALENV)/bin/activate;\
 	cd service;\
+	export PYTHONPATH=$(PYTHONPATH):`pwd`;\
 	trial --reporter=text test.unit
 
 unit_tests_js:
@@ -71,6 +73,7 @@ unit_tests_js:
 integration_tests_py:
 	@. $(VIRTUALENV)/bin/activate;\
 	cd service;\
+	export PYTHONPATH=$(PYTHONPATH):`pwd`;\
 	trial --reporter=text test.integration
 
 functional_tests: clean requirements install

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -5,7 +5,7 @@ pyasn1==0.1.9
 requests==2.11.1
 srp==1.0.6
 whoosh==2.6.0
-Twisted==16.1.1
+Twisted==17.1.0
 -e 'git+https://0xacab.org/leap/leap_pycommon.git@master#egg=leap.common'
 -e 'git+https://0xacab.org/pixelated/bitmask-dev.git@development#egg=leap.bitmask'
 -e 'git+https://0xacab.org/pixelated/soledad.git@development#egg=leap.soledad.common&subdirectory=common/'

--- a/service/test/unit/config/test_site.py
+++ b/service/test/unit/config/test_site.py
@@ -17,7 +17,7 @@
 from twisted.trial import unittest
 from mock import MagicMock
 from pixelated.config.site import PixelatedSite
-from twisted.protocols.basic import LineReceiver
+from twisted.web.test.requesthelper import DummyChannel
 
 
 class TestPixelatedSite(unittest.TestCase):
@@ -52,7 +52,7 @@ class TestPixelatedSite(unittest.TestCase):
         self.assertFalse(request.responseHeaders.hasHeader('Strict-Transport-Security'.lower()))
 
     def create_request(self):
-        channel = LineReceiver()
+        channel = DummyChannel()
         channel.site = PixelatedSite(MagicMock())
         request = PixelatedSite.requestFactory(channel=channel, queued=True)
         request.method = "GET"


### PR DESCRIPTION
Upgrades Twisted version to the latest available (17.1.0) which is also the version used by Leap.  According to the docs for Trial - https://twistedmatrix.com/documents/current/core/howto/trial.html - now we need to export - PYTHONPATH="$PYTHONPATH:`pwd`/.." in the `service` directory to make the tests work.