### PR TITLE
[#935] Sends user recovery code and password to account recovery endpoint

### DIFF
--- a/service/pixelated/resources/account_recovery_resource.py
+++ b/service/pixelated/resources/account_recovery_resource.py
@@ -21,6 +21,8 @@ from twisted.python.filepath import FilePath
 from pixelated.resources import get_public_static_folder
 from twisted.web.http import OK
 from twisted.web.template import Element, XMLFile, renderElement
+from twisted.web.server import NOT_DONE_YET
+from twisted.internet import defer
 
 
 class AccountRecoveryPage(Element):
@@ -44,3 +46,16 @@ class AccountRecoveryResource(BaseResource):
     def _render_template(self, request):
         site = AccountRecoveryPage()
         return renderElement(request, site)
+
+    def render_POST(self, request):
+        def success_response(response):
+            request.setResponseCode(OK)
+            request.finish()
+
+        def error_response(response):
+            request.setResponseCode(INTERNAL_SERVER_ERROR)
+            request.finish()
+
+        d = defer.succeed('Done!')
+        d.addCallbacks(success_response, error_response)
+        return NOT_DONE_YET

--- a/service/test/unit/resources/test_account_recovery_resource.py
+++ b/service/test/unit/resources/test_account_recovery_resource.py
@@ -42,3 +42,14 @@ class TestAccountRecoveryResource(unittest.TestCase):
 
         d.addCallback(assert_200_when_user_logged_in)
         return d
+
+    def test_post_returns_successfully(self):
+        request = DummyRequest(['/account-recovery'])
+        request.method = 'POST'
+        d = self.web.get(request)
+
+        def assert_successful_response(_):
+            self.assertEqual(200, request.responseCode)
+
+        d.addCallback(assert_successful_response)
+        return d

--- a/web-ui/src/account_recovery/new_password_form/new_password_form.js
+++ b/web-ui/src/account_recovery/new_password_form/new_password_form.js
@@ -15,17 +15,23 @@
  * along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'isomorphic-fetch';
 import React from 'react';
 import { translate } from 'react-i18next';
 
+import { submitForm } from 'src/common/util';
 import InputField from 'src/common/input_field/input_field';
 import SubmitButton from 'src/common/submit_button/submit_button';
 import BackLink from 'src/common/back_link/back_link';
 
 import './new_password_form.scss';
 
-export const NewPasswordForm = ({ t, previous }) => (
-  <form className='account-recovery-form new-password'>
+const submitHandler = code => event => (
+  submitForm(event, '/account-recovery', { userCode: code })
+);
+
+export const NewPasswordForm = ({ t, previous, userCode }) => (
+  <form className='account-recovery-form new-password' onSubmit={submitHandler(userCode)}>
     <img
       className='account-recovery-progress'
       src='/public/images/account-recovery/step_3.svg'
@@ -47,7 +53,8 @@ export const NewPasswordForm = ({ t, previous }) => (
 
 NewPasswordForm.propTypes = {
   t: React.PropTypes.func.isRequired,
-  previous: React.PropTypes.func.isRequired
+  previous: React.PropTypes.func.isRequired,
+  userCode: React.PropTypes.string.isRequired
 };
 
 export default translate('', { wait: true })(NewPasswordForm);

--- a/web-ui/src/account_recovery/new_password_form/new_password_form.js
+++ b/web-ui/src/account_recovery/new_password_form/new_password_form.js
@@ -26,30 +26,49 @@ import BackLink from 'src/common/back_link/back_link';
 
 import './new_password_form.scss';
 
-const submitHandler = code => event => (
-  submitForm(event, '/account-recovery', { userCode: code })
-);
+export class NewPasswordForm extends React.Component {
+  submitHandler = (event) => {
+    submitForm(event, '/account-recovery', {
+      userCode: this.props.userCode,
+      password: this.state.password,
+      confirmation: this.state.confirmation
+    });
+  }
 
-export const NewPasswordForm = ({ t, previous, userCode }) => (
-  <form className='account-recovery-form new-password' onSubmit={submitHandler(userCode)}>
-    <img
-      className='account-recovery-progress'
-      src='/public/images/account-recovery/step_3.svg'
-      alt={t('account-recovery.new-password-form.image-description')}
-    />
-    <h1>{t('account-recovery.new-password-form.title')}</h1>
-    <InputField
-      type='password' name='new-password'
-      label={t('account-recovery.new-password-form.input-label1')}
-    />
-    <InputField
-      type='password' name='confirm-password'
-      label={t('account-recovery.new-password-form.input-label2')}
-    />
-    <SubmitButton buttonText={t('account-recovery.button-next')} />
-    <BackLink text={t('account-recovery.back')} onClick={previous} />
-  </form>
-);
+  handlePasswordChange = (event) => {
+    this.setState({ password: event.target.value });
+  }
+
+  handlePasswordConfirmationChange = (event) => {
+    this.setState({ confirmation: event.target.value });
+  }
+
+  render() {
+    const { t, previous } = this.props;
+    return (
+      <form className='account-recovery-form new-password' onSubmit={this.submitHandler}>
+        <img
+          className='account-recovery-progress'
+          src='/public/images/account-recovery/step_3.svg'
+          alt={t('account-recovery.new-password-form.image-description')}
+        />
+        <h1>{t('account-recovery.new-password-form.title')}</h1>
+        <InputField
+          type='password' name='new-password'
+          label={t('account-recovery.new-password-form.input-label1')}
+          onChange={this.handlePasswordChange}
+        />
+        <InputField
+          type='password' name='confirm-password'
+          label={t('account-recovery.new-password-form.input-label2')}
+          onChange={this.handlePasswordConfirmationChange}
+        />
+        <SubmitButton buttonText={t('account-recovery.button-next')} />
+        <BackLink text={t('account-recovery.back')} onClick={previous} />
+      </form>
+    );
+  }
+}
 
 NewPasswordForm.propTypes = {
   t: React.PropTypes.func.isRequired,

--- a/web-ui/src/account_recovery/new_password_form/new_password_form.spec.js
+++ b/web-ui/src/account_recovery/new_password_form/new_password_form.spec.js
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import expect from 'expect';
 import React from 'react';
+import fetchMock from 'fetch-mock';
 import { NewPasswordForm } from './new_password_form';
 
 describe('NewPasswordForm', () => {
@@ -11,7 +12,7 @@ describe('NewPasswordForm', () => {
     const mockTranslations = key => key;
     mockPrevious = expect.createSpy();
     newPasswordForm = shallow(
-      <NewPasswordForm t={mockTranslations} previous={mockPrevious} />
+      <NewPasswordForm t={mockTranslations} previous={mockPrevious} userCode='def234' />
     );
   });
 
@@ -36,5 +37,20 @@ describe('NewPasswordForm', () => {
   it('returns to previous step on link click', () => {
     newPasswordForm.find('BackLink').simulate('click');
     expect(mockPrevious).toHaveBeenCalled();
+  });
+
+  describe('Submit', () => {
+    beforeEach(() => {
+      fetchMock.post('/account-recovery', 200);
+      newPasswordForm.find('form').simulate('submit', { preventDefault: expect.createSpy() });
+    });
+
+    it('posts to account recovery', () => {
+      expect(fetchMock.called('/account-recovery')).toBe(true, 'POST was not called');
+    });
+
+    it('sends user code as content', () => {
+      expect(fetchMock.lastOptions('/account-recovery').body).toContain('"userCode":"def234"');
+    });
   });
 });

--- a/web-ui/src/account_recovery/new_password_form/new_password_form.spec.js
+++ b/web-ui/src/account_recovery/new_password_form/new_password_form.spec.js
@@ -42,6 +42,8 @@ describe('NewPasswordForm', () => {
   describe('Submit', () => {
     beforeEach(() => {
       fetchMock.post('/account-recovery', 200);
+      newPasswordForm.find('InputField[name="new-password"]').simulate('change', { target: { value: '123' } });
+      newPasswordForm.find('InputField[name="confirm-password"]').simulate('change', { target: { value: '456' } });
       newPasswordForm.find('form').simulate('submit', { preventDefault: expect.createSpy() });
     });
 
@@ -51,6 +53,14 @@ describe('NewPasswordForm', () => {
 
     it('sends user code as content', () => {
       expect(fetchMock.lastOptions('/account-recovery').body).toContain('"userCode":"def234"');
+    });
+
+    it('sends password as content', () => {
+      expect(fetchMock.lastOptions('/account-recovery').body).toContain('"password":"123"');
+    });
+
+    it('sends password confirmation as content', () => {
+      expect(fetchMock.lastOptions('/account-recovery').body).toContain('"confirmation":"456"');
     });
   });
 });

--- a/web-ui/src/account_recovery/page.js
+++ b/web-ui/src/account_recovery/page.js
@@ -32,7 +32,7 @@ export class Page extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { step: 0 };
+    this.state = { step: 0, userCode: '' };
   }
 
   nextStep = (event) => {
@@ -44,13 +44,19 @@ export class Page extends React.Component {
     this.setState({ step: this.state.step - 1 });
   }
 
-  steps = {
-    0: <AdminRecoveryCodeForm next={this.nextStep} />,
-    1: <UserRecoveryCodeForm previous={this.previousStep} next={this.nextStep} />,
-    2: <NewPasswordForm previous={this.previousStep} />
+  saveUserCode = (event) => {
+    this.setState({ userCode: event.target.value });
   }
 
-  mainContent = () => this.steps[this.state.step];
+  steps = () => ({
+    0: <AdminRecoveryCodeForm next={this.nextStep} />,
+    1: (<UserRecoveryCodeForm
+      previous={this.previousStep} next={this.nextStep} saveCode={this.saveUserCode}
+    />),
+    2: <NewPasswordForm previous={this.previousStep} userCode={this.state.userCode} />
+  })
+
+  mainContent = () => this.steps()[this.state.step];
 
   render() {
     const t = this.props.t;

--- a/web-ui/src/account_recovery/page.spec.js
+++ b/web-ui/src/account_recovery/page.spec.js
@@ -12,10 +12,12 @@ import NewPasswordFormWrapper from './new_password_form/new_password_form';
 
 describe('Account Recovery Page', () => {
   let page;
+  let pageInstance;
 
   beforeEach(() => {
     const mockTranslations = key => key;
     page = shallow(<Page t={mockTranslations} />);
+    pageInstance = page.instance();
   });
 
   it('renders account recovery page title', () => {
@@ -30,13 +32,12 @@ describe('Account Recovery Page', () => {
     expect(page.find(Footer).length).toEqual(1);
   });
 
+  it('saves user code', () => {
+    pageInstance.saveUserCode({ target: { value: '123' } });
+    expect(pageInstance.state.userCode).toEqual('123');
+  });
+
   context('main content', () => {
-    let pageInstance;
-
-    beforeEach(() => {
-      pageInstance = page.instance();
-    });
-
     it('renders admin recovery code form as default form', () => {
       expect(page.find(AdminRecoveryCodeFormWrapper).length).toEqual(1);
       expect(page.find(UserRecoveryCodeFormWrapper).length).toEqual(0);

--- a/web-ui/src/account_recovery/user_recovery_code_form/user_recovery_code_form.js
+++ b/web-ui/src/account_recovery/user_recovery_code_form/user_recovery_code_form.js
@@ -24,7 +24,7 @@ import BackLink from 'src/common/back_link/back_link';
 
 import './user_recovery_code_form.scss';
 
-export const UserRecoveryCodeForm = ({ t, previous, next }) => (
+export const UserRecoveryCodeForm = ({ t, previous, next, saveCode }) => (
   <form className='account-recovery-form user-code' onSubmit={next}>
     <img
       className='account-recovery-progress'
@@ -40,7 +40,10 @@ export const UserRecoveryCodeForm = ({ t, previous, next }) => (
       />
       <p>{t('account-recovery.user-form.description')}</p>
     </div>
-    <InputField name='admin-code' label={t('account-recovery.user-form.input-label')} />
+    <InputField
+      name='user-code' label={t('account-recovery.user-form.input-label')}
+      onChange={saveCode}
+    />
     <SubmitButton buttonText={t('account-recovery.button-next')} />
     <BackLink text={t('account-recovery.back')} onClick={previous} />
   </form>
@@ -49,7 +52,8 @@ export const UserRecoveryCodeForm = ({ t, previous, next }) => (
 UserRecoveryCodeForm.propTypes = {
   t: React.PropTypes.func.isRequired,
   previous: React.PropTypes.func.isRequired,
-  next: React.PropTypes.func.isRequired
+  next: React.PropTypes.func.isRequired,
+  saveCode: React.PropTypes.func.isRequired
 };
 
 export default translate('', { wait: true })(UserRecoveryCodeForm);

--- a/web-ui/src/account_recovery/user_recovery_code_form/user_recovery_code_form.spec.js
+++ b/web-ui/src/account_recovery/user_recovery_code_form/user_recovery_code_form.spec.js
@@ -7,14 +7,17 @@ describe('UserRecoveryCodeForm', () => {
   let userRecoveryCodeForm;
   let mockNext;
   let mockPrevious;
+  let mockSaveCode;
 
   beforeEach(() => {
     const mockTranslations = key => key;
     mockNext = expect.createSpy();
     mockPrevious = expect.createSpy();
+    mockSaveCode = expect.createSpy();
     userRecoveryCodeForm = shallow(
       <UserRecoveryCodeForm
-        t={mockTranslations} next={mockNext} previous={mockPrevious}
+        t={mockTranslations} next={mockNext}
+        previous={mockPrevious} saveCode={mockSaveCode}
       />
     );
   });
@@ -43,5 +46,10 @@ describe('UserRecoveryCodeForm', () => {
   it('returns to previous step on link click', () => {
     userRecoveryCodeForm.find('BackLink').simulate('click');
     expect(mockPrevious).toHaveBeenCalled();
+  });
+
+  it('saves code on input change', () => {
+    userRecoveryCodeForm.find('InputField').simulate('change', '123');
+    expect(mockSaveCode).toHaveBeenCalledWith('123');
   });
 });

--- a/web-ui/src/backup_account/backup_email/backup_email.js
+++ b/web-ui/src/backup_account/backup_email/backup_email.js
@@ -19,8 +19,8 @@ import 'isomorphic-fetch';
 import React from 'react';
 import { translate } from 'react-i18next';
 import validator from 'validator';
-import browser from 'helpers/browser';
 
+import { submitForm } from 'src/common/util';
 import SubmitButton from 'src/common/submit_button/submit_button';
 import InputField from 'src/common/input_field/input_field';
 import BackLink from 'src/common/back_link/back_link';
@@ -45,24 +45,11 @@ export class BackupEmail extends React.Component {
   };
 
   submitHandler = (event) => {
-    event.preventDefault();
-
-    fetch('/backup-account', {
-      credentials: 'same-origin',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        csrftoken: [browser.getCookie('XSRF-TOKEN')],
-        backupEmail: this.state.backupEmail
-      })
+    submitForm(event, '/backup-account', {
+      backupEmail: this.state.backupEmail
     }).then((response) => {
-      if (response.ok) {
-        this.props.onSubmit('success');
-      } else {
-        this.props.onSubmit('error');
-      }
+      if (response.ok) this.props.onSubmit('success');
+      else this.props.onSubmit('error');
     });
   };
 

--- a/web-ui/src/backup_account/backup_email/backup_email.spec.js
+++ b/web-ui/src/backup_account/backup_email/backup_email.spec.js
@@ -3,7 +3,6 @@ import expect from 'expect';
 import React from 'react';
 import fetchMock from 'fetch-mock';
 import { BackupEmail } from 'src/backup_account/backup_email/backup_email';
-import browser from 'helpers/browser';
 
 describe('BackupEmail', () => {
   let backupEmail;
@@ -104,7 +103,6 @@ describe('BackupEmail', () => {
     context('on success', () => {
       beforeEach((done) => {
         mockOnSubmit = expect.createSpy().andCall(() => done());
-        expect.spyOn(browser, 'getCookie').andReturn('abc123');
 
         fetchMock.post('/backup-account', 204);
         backupEmail = shallow(<BackupEmail t={mockTranslations} onSubmit={mockOnSubmit} />);
@@ -117,24 +115,8 @@ describe('BackupEmail', () => {
         expect(fetchMock.called('/backup-account')).toBe(true, 'Backup account POST was not called');
       });
 
-      it('sends csrftoken as content', () => {
-        expect(fetchMock.lastOptions('/backup-account').body).toContain('"csrftoken":["abc123"]');
-      });
-
       it('sends user email as content', () => {
         expect(fetchMock.lastOptions('/backup-account').body).toContain('"backupEmail":"test@test.com"');
-      });
-
-      it('sends content-type header', () => {
-        expect(fetchMock.lastOptions('/backup-account').headers['Content-Type']).toEqual('application/json');
-      });
-
-      it('sends same origin headers', () => {
-        expect(fetchMock.lastOptions('/backup-account').credentials).toEqual('same-origin');
-      });
-
-      it('prevents default call to refresh page', () => {
-        expect(preventDefaultSpy).toHaveBeenCalled();
       });
 
       it('calls onSubmit from props with success', () => {

--- a/web-ui/src/common/util.js
+++ b/web-ui/src/common/util.js
@@ -1,8 +1,27 @@
+import browser from 'helpers/browser';
+
 export const hasQueryParameter = (param) => {
   const decodedUri = decodeURIComponent(window.location.search.substring(1));
   return !(decodedUri.split('&').indexOf(param) < 0);
 };
 
+export const submitForm = (event, url, body = {}) => {
+  event.preventDefault();
+
+  return fetch(url, {
+    credentials: 'same-origin',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      csrftoken: [browser.getCookie('XSRF-TOKEN')],
+      ...body
+    })
+  });
+};
+
 export default {
-  hasQueryParameter
+  hasQueryParameter,
+  submitForm
 };

--- a/web-ui/src/common/util.spec.js
+++ b/web-ui/src/common/util.spec.js
@@ -1,4 +1,7 @@
 import expect from 'expect';
+import fetchMock from 'fetch-mock';
+
+import browser from 'helpers/browser';
 import Util from 'src/common/util';
 
 describe('Utils', () => {
@@ -15,6 +18,38 @@ describe('Utils', () => {
 
     it('checks if param not included in query parameters', () => {
       expect(Util.hasQueryParameter('error')).toBe(false);
+    });
+  });
+
+  describe('submitForm', () => {
+    const event = {};
+
+    beforeEach(() => {
+      event.preventDefault = expect.createSpy();
+      expect.spyOn(browser, 'getCookie').andReturn('abc123');
+
+      fetchMock.post('/some-url', 200);
+      Util.submitForm(event, '/some-url', { userCode: '123' });
+    });
+
+    it('sends csrftoken as content', () => {
+      expect(fetchMock.lastOptions('/some-url').body).toContain('"csrftoken":["abc123"]');
+    });
+
+    it('sends body as content', () => {
+      expect(fetchMock.lastOptions('/some-url').body).toContain('"userCode":"123"');
+    });
+
+    it('sends content-type header', () => {
+      expect(fetchMock.lastOptions('/some-url').headers['Content-Type']).toEqual('application/json');
+    });
+
+    it('sends same origin headers', () => {
+      expect(fetchMock.lastOptions('/some-url').credentials).toEqual('same-origin');
+    });
+
+    it('prevents default call to refresh page', () => {
+      expect(event.preventDefault).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This starts the implementation of login with the recovery code.

To do:
- [ ] Capture user's username from url
- [ ] Call bonafide handshake and login with recovery code