### PR TITLE
Ship our local version of google-chrome and chromedriver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,11 @@ integration_tests_py:
 
 functional_tests: clean requirements install
 	@. $(VIRTUALENV)/bin/activate;\
-	export PATH=$(PATH):/usr/lib/chromium/;\
 	cd service;\
 	xvfb-run --server-args="-screen 0 1280x1024x24" behave --tags ~@wip --tags ~@smoke test/functional/features
 
 smoke_tests: clean install
 	@. $(VIRTUALENV)/bin/activate;\
-	export PATH=$(PATH):/usr/lib/chromium/;\
 	cd service;\
 	xvfb-run --server-args="-screen 0 1280x1024x24" behave --tags ~@wip --tags @smoke test/functional/features -k -D host=$(provider)
 
@@ -96,7 +94,6 @@ functional_tests_ci: clean requirements install
 
 functional_tests_wip:
 	@. $(VIRTUALENV)/bin/activate;\
-	export PATH=$(PATH):/usr/lib/chromium/;\
 	cd service;\
 	xvfb-run --server-args="-screen 0 1280x1024x24" behave --tags @wip test/functional/features
 

--- a/provisioning/modules/chromedriver/manifests/init.pp
+++ b/provisioning/modules/chromedriver/manifests/init.pp
@@ -1,0 +1,37 @@
+# install chromedriver for functional tests
+# we ship our local copy of chromedriver
+# because latest versions are getting recurring errors on
+# test/functional/features/login.feature#Then I should see the fancy interstitial
+
+class chromedriver (
+  $release       = '1.0_beta1',
+  $chromedriver  = 'chromedriver_2.27_linux64.zip',
+  $google_chrome = 'google-chrome-stable_54.0.2840.100-1_amd64.deb',
+) {
+
+  exec { 'fetch_chromedriver':
+    command => "/usr/bin/wget https://github.com/pixelated/pixelated-user-agent/releases/download/${release}/${chromedriver}",
+    cwd     => '/var/tmp',
+    creates => "/var/tmp/${chromedriver}",
+  }
+
+  exec { 'fetch_google_chrome':
+    command => "/usr/bin/wget https://github.com/pixelated/pixelated-user-agent/releases/download/${release}/${google_chrome}",
+    cwd     => '/var/tmp',
+    creates => "/var/tmp/${google_chrome}",
+  }
+
+  exec { 'unpack_chromedriver':
+    command => "/usr/bin/unzip ${chromedriver} -d /usr/local/bin/",
+    cwd     => '/var/tmp/',
+    creates => '/usr/local/bin/chromedriver',
+  }
+
+  exec { 'install_google_chrome':
+    command => "/usr/bin/dpkg -i ${google_chrome} || /usr/bin/apt-get -y -f install",
+    cwd     => '/var/tmp/',
+    unless  => '/usr/bin/dpkg -l google-chrome-stable > /dev/null 2>&1',
+    require => [ Exec['apt_get_update'] ],
+  }
+
+}

--- a/provisioning/modules/chromedriver/manifests/init.pp
+++ b/provisioning/modules/chromedriver/manifests/init.pp
@@ -25,13 +25,14 @@ class chromedriver (
     command => "/usr/bin/unzip ${chromedriver} -d /usr/local/bin/",
     cwd     => '/var/tmp/',
     creates => '/usr/local/bin/chromedriver',
+    require => [ Exec['fetch_chromedriver'] ],
   }
 
   exec { 'install_google_chrome':
     command => "/usr/bin/dpkg -i ${google_chrome} || /usr/bin/apt-get -y -f install",
     cwd     => '/var/tmp/',
     unless  => '/usr/bin/dpkg -l google-chrome-stable > /dev/null 2>&1',
-    require => [ Exec['apt_get_update'] ],
+    require => [ Exec['fetch_google_chrome'], Exec['apt_get_update'] ],
   }
 
 }

--- a/provisioning/modules/pixelated/manifests/source.pp
+++ b/provisioning/modules/pixelated/manifests/source.pp
@@ -1,5 +1,6 @@
 # install requirements for setting up the useragent from source
 class pixelated::source {
+  include chromedriver
 
   package { [
     'git',
@@ -15,14 +16,13 @@ class pixelated::source {
     'ruby-compass',
     'xvfb',
     'xauth',
-    'chromedriver',
     'phantomjs'
     ]:
       ensure => latest
   }
 
   package { ['sass', 'compass']:
-    ensure => latest,
+    ensure   => latest,
     provider => 'gem',
   }
 


### PR DESCRIPTION
Fix functional test step `Then I should see the fancy interstitial`, that's not working properly with newer versions of chromedriver.

Since the debian repo doesn't provide old versions of chromium, we're [shipping][1] our own local copies:

```
$ chromedriver --version
ChromeDriver 2.27.440175 (9bc1d90b8bfa4dd181fbbf769a5eb5e575574320)
```
```
$ google-chrome --version
Google Chrome 54.0.2840.100
```

[1]: https://github.com/pixelated/pixelated-user-agent/releases/tag/1.0_beta1